### PR TITLE
CPU backend fallback

### DIFF
--- a/src/ggml-hsa/CMakeLists.txt
+++ b/src/ggml-hsa/CMakeLists.txt
@@ -19,6 +19,8 @@ find_package(hsa-runtime64 1.0 REQUIRED)
 
 message(STATUS "HSA found")
 
+option(GGML_HSA_CPU_FALLBACK "ggml: use fallback to CPU if HSA kernel not implemented" OFF)
+
 set(GGML_HEADERS_HSA ../../include/ggml-hsa.h)
 set(GGML_SOURCES_HSA
     ggml-hsa.cpp
@@ -40,5 +42,9 @@ target_link_libraries(ggml-hsa PRIVATE Eigen3::Eigen)
 target_sources(ggml-hsa PRIVATE common.hpp kernels.hpp)
 
 set_source_files_properties(${GGML_SOURCES_ROCM} PROPERTIES LANGUAGE CXX)
+
+if (GGML_HSA_CPU_FALLBACK)
+    target_compile_definitions(ggml-hsa PRIVATE -DGGML_HSA_CPU_FALLBACK)
+endif ()
 
 add_compile_definitions(GGML_USE_HSA)

--- a/src/ggml-hsa/common.hpp
+++ b/src/ggml-hsa/common.hpp
@@ -88,6 +88,10 @@ struct ggml_backend_hsa_context {
     std::string name;               ///< Device name.
     hsa_queue_t* queue{};           ///< HSA queue associated with the context.
     hsa_signal_t dispatch_signal{}; ///< Signal to wait for dispatches.
+#ifdef GGML_HSA_CPU_FALLBACK
+    ggml_backend_t fallback_backend{}; ///< Fallback backend for operations not supported by HSA.
+    ggml_gallocr_t fallback_galloc{};  ///< Fallback graph allocator.
+#endif
 
     ggml_backend_hsa_context(std::int32_t device, const ggml_hsa_device_info::hsa_device_info& device_info);
 


### PR DESCRIPTION
This PR allows the HSA backend to fallback to a CPU implementation. Very slow but useful until we have enough kernels implemented.