### PR TITLE
Matrix multiplication kernel

### DIFF
--- a/cmake/ggml-config.cmake.in
+++ b/cmake/ggml-config.cmake.in
@@ -69,6 +69,11 @@ if (NOT GGML_SHARED_LIB)
         list(APPEND GGML_VULKAN_INTERFACE_LINK_LIBRARIES Vulkan::Vulkan)
     endif()
 
+    if (GGML_HSA)
+        find_package(hsa-runtime64 1.0 REQUIRED)
+        list(APPEND GGML_HSA_INTERFACE_LINK_LIBRARIES hsa-runtime64::hsa-runtime64)
+    endif()
+
     if (GGML_HIP)
         find_package(hip     REQUIRED)
         find_package(hipblas REQUIRED)

--- a/examples/simple/CMakeLists.txt
+++ b/examples/simple/CMakeLists.txt
@@ -13,7 +13,7 @@ add_executable(${TEST_TARGET} simple-backend.cpp)
 target_link_libraries(${TEST_TARGET} PRIVATE ggml)
 
 #
-# test-add
+# simple-add
 
 set(TEST_TARGET simple-add)
 add_executable(${TEST_TARGET} ${TEST_TARGET}.cpp)

--- a/examples/simple/simple-add.cpp
+++ b/examples/simple/simple-add.cpp
@@ -7,7 +7,14 @@
 #include <vector>
 
 #include "ggml.h"
+
+#ifdef GGML_USE_CUDA
+#include "ggml-cuda.h"
+#endif
+
+#ifdef GGML_USE_HSA
 #include "ggml-hsa.h"
+#endif
 
 template<typename T>
 auto create_data(std::size_t N, T value) {
@@ -32,7 +39,20 @@ int main(void) {
     const std::vector<std::int32_t> B = create_data<std::int32_t>(N, 1);
 
     // initialize GGML backend and allocators
-    ggml_backend_t backend = ggml_backend_hsa_init(0);
+    ggml_backend_t backend = {};
+
+#ifdef GGML_USE_HSA
+    std::cout << "Using HSA backend\n";
+    backend = ggml_backend_hsa_init(0);
+#endif
+
+#ifdef GGML_USE_CUDA
+    if (!backend) {
+        std::cout << "Using CUDA backend\n";
+        backend = ggml_backend_cuda_init(0); // init device 0
+    }
+#endif
+
     if (backend == nullptr) {
         std::cerr << "Could not create backend\n";
         return EXIT_FAILURE;

--- a/src/ggml-hsa/CMakeLists.txt
+++ b/src/ggml-hsa/CMakeLists.txt
@@ -8,7 +8,7 @@ else()
     set(ROCM_PATH $ENV{ROCM_PATH})
 endif()
 
-list(APPEND CMAKE_PREFIX_PATH  ${ROCM_PATH})
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH})
 
 # Forward AMDGPU_TARGETS to CMAKE_HIP_ARCHITECTURES.
 if (AMDGPU_TARGETS AND NOT CMAKE_HIP_ARCHITECTURES)
@@ -16,8 +16,6 @@ if (AMDGPU_TARGETS AND NOT CMAKE_HIP_ARCHITECTURES)
 endif()
 
 find_package(hsa-runtime64 1.0 REQUIRED)
-
-message(STATUS "HSA found")
 
 option(GGML_HSA_CPU_FALLBACK "ggml: use fallback to CPU if HSA kernel not implemented" OFF)
 

--- a/src/ggml-hsa/CMakeLists.txt
+++ b/src/ggml-hsa/CMakeLists.txt
@@ -35,76 +35,7 @@ ggml_add_backend_library(ggml-hsa
                          ${GGML_SOURCES_HSA}
                          )
 
-#
-# Kernel generation
-#
-
-find_package(PythonInterp REQUIRED)
-find_package(Python REQUIRED)
-
-function(add_aie_kernel TARGET KERNEL DEV DTYPE DIMS)
-    set(KERNEL_NAME "${KERNEL}-${DEV}-${DIMS}${DTYPE}")
-    set(KERNEL_FILE "${CMAKE_CURRENT_SOURCE_DIR}/kernels/${KERNEL}.py")
-    set(OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/kernels")
-
-    set(MLIR_OUTPUT "${OUTPUT_DIR}/${KERNEL_NAME}.mlir")
-    add_custom_command(
-        OUTPUT ${MLIR_OUTPUT}
-        COMMAND ${PYTHON_EXECUTABLE} ${KERNEL_FILE} --dev ${DEV} --dtype ${DTYPE} --dims ${DIMS} > ${MLIR_OUTPUT}
-        DEPENDS ${KERNEL_FILE}
-        COMMENT "Generating AIE MLIR file for ${KERNEL_NAME} in ${MLIR_OUTPUT}"
-        VERBATIM
-    )
-
-    set(XCLBIN_OUTPUT "${OUTPUT_DIR}/${KERNEL_NAME}.xclbin")
-    set(INSTS_OUTPUT "${OUTPUT_DIR}/${KERNEL_NAME}_insts.txt")
-    add_custom_command(
-        OUTPUT ${XCLBIN_OUTPUT}
-        COMMAND aiecc.py --aie-generate-cdo --aie-generate-npu --no-compile-host --no-xchesscc --no-xbridge
-                --xclbin-name=${XCLBIN_OUTPUT} --npu-insts-name=${INSTS_OUTPUT} ${MLIR_OUTPUT}
-        DEPENDS ${MLIR_OUTPUT}
-        COMMENT "Generating xclbin for ${KERNEL_NAME} in ${XCLBIN_OUTPUT}"
-        VERBATIM
-    )
-
-    set(AIE_PARTITION_OUTPUT "${OUTPUT_DIR}/${KERNEL_NAME}_partition.json")
-    add_custom_command(
-        OUTPUT ${AIE_PARTITION_OUTPUT}
-        COMMAND xclbinutil --dump-section AIE_PARTITION:JSON:${AIE_PARTITION_OUTPUT} --force --input ${XCLBIN_OUTPUT}
-        DEPENDS ${XCLBIN_OUTPUT}
-        COMMENT "Extracting PDI for ${KERNEL_NAME} with JSON in ${AIE_PARTITION_OUTPUT}"
-        VERBATIM
-    )
-
-    set(PDI_OUTPUT "${OUTPUT_DIR}/${KERNEL_NAME}.pdi")
-    add_custom_command(
-        OUTPUT ${PDI_OUTPUT}
-        COMMAND bash -c "cp ${OUTPUT_DIR}/`jq --raw-output \".aie_partition.PDIs.[0].file_name\" ${AIE_PARTITION_OUTPUT}` ${PDI_OUTPUT}"
-        DEPENDS ${AIE_PARTITION_OUTPUT}
-        COMMENT "Copying PDI for ${KERNEL_NAME} to ${PDI_OUTPUT}"
-        VERBATIM
-    )
-
-    add_custom_target(ggml_hsa_kernel_${KERNEL_NAME} ALL DEPENDS ${PDI_OUTPUT})
-    add_dependencies(${TARGET} ggml_hsa_kernel_${KERNEL_NAME})
-endfunction()
-
-add_aie_kernel(ggml-hsa add aie2 i32 16)
-add_aie_kernel(ggml-hsa add aie2 i32 256)
-add_aie_kernel(ggml-hsa add aie2 f32 256)
-add_aie_kernel(ggml-hsa add aie2 i32 512)
-
-#
-# Eigen
-#
-
-find_package(Eigen3 3.3 REQUIRED)
-
-target_link_libraries(ggml-hsa PRIVATE Eigen3::Eigen)
-
-#
-#
-#
+add_subdirectory(kernels)
 
 target_link_libraries(ggml-hsa PRIVATE ggml-base hsa-runtime64::hsa-runtime64)
 target_include_directories(ggml-hsa PRIVATE . ..)

--- a/src/ggml-hsa/CMakeLists.txt
+++ b/src/ggml-hsa/CMakeLists.txt
@@ -35,7 +35,7 @@ ggml_add_backend_library(ggml-hsa
 
 add_subdirectory(kernels)
 
-target_link_libraries(ggml-hsa PRIVATE ggml-base hsa-runtime64::hsa-runtime64)
+target_link_libraries(ggml-hsa PRIVATE ggml-base hsa-runtime64::hsa-runtime64 ${GGML_CPU_NAME})
 target_include_directories(ggml-hsa PRIVATE . ..)
 
 target_sources(ggml-hsa PRIVATE common.hpp kernels.hpp)

--- a/src/ggml-hsa/CMakeLists.txt
+++ b/src/ggml-hsa/CMakeLists.txt
@@ -43,7 +43,7 @@ find_package(PythonInterp REQUIRED)
 find_package(Python REQUIRED)
 
 function(add_aie_kernel TARGET KERNEL DEV DTYPE DIMS)
-    set(KERNEL_NAME "${KERNEL}-${DEV}-${DTYPE}-${DIMS}")
+    set(KERNEL_NAME "${KERNEL}-${DEV}-${DIMS}${DTYPE}")
     set(KERNEL_FILE "${CMAKE_CURRENT_SOURCE_DIR}/kernels/${KERNEL}.py")
     set(OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/kernels")
 

--- a/src/ggml-hsa/CMakeLists.txt
+++ b/src/ggml-hsa/CMakeLists.txt
@@ -91,6 +91,7 @@ endfunction()
 
 add_aie_kernel(ggml-hsa add aie2 i32 16)
 add_aie_kernel(ggml-hsa add aie2 i32 256)
+add_aie_kernel(ggml-hsa add aie2 f32 256)
 add_aie_kernel(ggml-hsa add aie2 i32 512)
 
 #

--- a/src/ggml-hsa/add.cpp
+++ b/src/ggml-hsa/add.cpp
@@ -4,22 +4,9 @@
 
 bool ggml_hsa_supports_add(const ggml_hsa_device_info::device_info & dev_info,
                            const ggml_tensor * tensor) {
-    const ggml_tensor * src0 = tensor->src[0];
-    const ggml_tensor * src1 = tensor->src[1];
-    const ggml_tensor * dst = tensor;
-
-    // only contiguous tensors are supported
-    if (!ggml_is_contiguous(src0) || !ggml_is_contiguous(src1) || !ggml_is_contiguous(dst)) {
-        return false;
-    }
-
-    // input and output datatypes need to match
-    if ((src0->type != src1->type) || (src0->type != dst->type)) {
-        return false;
-    }
-
-    GGML_ASSERT(ggml_is_vector(src0) && ggml_are_same_shape(src0, src1) &&
-                ggml_are_same_shape(src0, dst));
+    GGML_ASSERT(ggml_is_vector(tensor->src[0]) &&
+                ggml_are_same_shape(tensor->src[0], tensor->src[1]) &&
+                ggml_are_same_shape(tensor->src[0], tensor));
 
     return ggml_hsa_kernel_exists(dev_info, tensor);
 }

--- a/src/ggml-hsa/add.cpp
+++ b/src/ggml-hsa/add.cpp
@@ -8,12 +8,18 @@ bool ggml_hsa_supports_add(const ggml_hsa_device_info::device_info & dev_info,
     const ggml_tensor * src1 = tensor->src[1];
     const ggml_tensor * dst = tensor;
 
-    GGML_ASSERT(ggml_is_vector(src0) && ggml_are_same_shape(src0, src1) &&
-                ggml_are_same_shape(src0, dst));
+    // only contiguous tensors are supported
+    if (!ggml_is_contiguous(src0) || !ggml_is_contiguous(src1) || !ggml_is_contiguous(dst)) {
+        return false;
+    }
 
+    // input and output datatypes need to match
     if ((src0->type != src1->type) || (src0->type != dst->type)) {
         return false;
     }
+
+    GGML_ASSERT(ggml_is_vector(src0) && ggml_are_same_shape(src0, src1) &&
+                ggml_are_same_shape(src0, dst));
 
     return ggml_hsa_kernel_exists(dev_info, tensor);
 }

--- a/src/ggml-hsa/ggml-hsa.cpp
+++ b/src/ggml-hsa/ggml-hsa.cpp
@@ -1096,19 +1096,6 @@ static bool ggml_backend_hsa_device_supports_op(ggml_backend_dev_t dev,
     const auto & info = ggml_hsa_info();
     const auto & dev_info = info.devices[dev_ctx.device];
 
-    // for now, only contiguous tensors are supported
-    if (!ggml_is_contiguous(tensor)) {
-        return false;
-    }
-    for (int i = 0; i < GGML_MAX_SRC; ++i) {
-        if (tensor->src[i] == nullptr) {
-            break;
-        }
-        if (!ggml_is_contiguous(tensor->src[i])) {
-            return false;
-        }
-    }
-
     switch (tensor->op) {
         case GGML_OP_NONE :
             return true;

--- a/src/ggml-hsa/kernels/CMakeLists.txt
+++ b/src/ggml-hsa/kernels/CMakeLists.txt
@@ -36,21 +36,25 @@ mark_as_advanced(MLIR_AIE_INCLUDE_DIR)
 # This function generates PDI and insts files that are set as dependencies to `TARGET`.
 #
 # Arguments:
-#     TARGET (string): target
-#     KERNEL (string): kernel source file
+#     TARGET_NAME (string): target
+#     SOURCE (string): kernel source file
+#     KERNEL_NAME (string): kernel name
 #     DEVICE (string): target device
+#     KERNEL_SUFFIX (string): kernel name suffix
+#     KERNEL_ARGS (string): kernel compilation flags
 #     OBJECT_FILE (string): Peano output file
+#     COMPILE_ARGS (string): Peano compilation flags
 #
-function(add_aie_iron_kernel TARGET)
+function(add_aie_iron_kernel TARGET_NAME)
     set(options)
-    set(oneValueArgs KERNEL KERNEL_SUFFIX DEVICE OBJECT_FILE)
-    set(multiValueArgs KERNEL_ARGS COMPILE_FLAGS)
+    set(oneValueArgs SOURCE KERNEL_NAME DEVICE KERNEL_SUFFIX OBJECT_FILE)
+    set(multiValueArgs KERNEL_ARGS COMPILE_ARGS)
 
     cmake_parse_arguments(PARSE_ARGV 0 arg
         "${options}" "${oneValueArgs}" "${multiValueArgs}")
 
-    set(KERNEL_NAME "${arg_KERNEL}-${arg_DEVICE}-${arg_KERNEL_SUFFIX}")
-    set(KERNEL_FILE "${CMAKE_CURRENT_SOURCE_DIR}/${arg_KERNEL}.py")
+    set(KERNEL_NAME "${arg_KERNEL_NAME}-${arg_DEVICE}-${arg_KERNEL_SUFFIX}")
+    set(KERNEL_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/${arg_SOURCE}")
     set(MLIR_OUTPUT "${KERNEL_NAME}.mlir")
     set(XCLBIN_OUTPUT "${KERNEL_NAME}.xclbin")
     set(INSTS_OUTPUT "${KERNEL_NAME}_insts.txt")
@@ -59,8 +63,8 @@ function(add_aie_iron_kernel TARGET)
 
     add_custom_command(
         OUTPUT ${MLIR_OUTPUT}
-        COMMAND ${Python_EXECUTABLE} ${KERNEL_FILE} ${arg_KERNEL_ARGS} > ${MLIR_OUTPUT}
-        DEPENDS ${KERNEL_FILE}
+        COMMAND ${Python_EXECUTABLE} ${KERNEL_SOURCE} ${arg_KERNEL_ARGS} > ${MLIR_OUTPUT}
+        DEPENDS ${KERNEL_SOURCE}
         BYPRODUCTS ${KERNEL_NAME}.mlir.prj
         COMMENT "Generating AIE MLIR file for ${KERNEL_NAME} in ${MLIR_OUTPUT}"
         VERBATIM
@@ -70,23 +74,24 @@ function(add_aie_iron_kernel TARGET)
     if (DEFINED arg_OBJECT_FILE)
         set(PEANO_WARNING_FLAGS -Wno-parentheses -Wno-attributes -Wno-macro-redefined)
         set(PEANO_FLAGS -O2 -std=c++20 --target=aie2-none-unknown-elf ${PEANO_WARNING_FLAGS} -DNDEBUG)
-        set(AIE_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/${arg_KERNEL}.cc")
-        set(AIE_OBJECT "${CMAKE_CURRENT_BINARY_DIR}/${arg_OBJECT_FILE}")
+        set(PEANO_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/${arg_SOURCE}")
+        string(REPLACE ".py" ".cc" PEANO_SOURCE ${PEANO_SOURCE})
+        set(PEANO_OUTPUT "${arg_OBJECT_FILE}")
 
         set(PEANO_COMPILE_DEFS "")
-        foreach(device_flag ${arg_COMPILE_FLAGS})
+        foreach(device_flag ${arg_COMPILE_ARGS})
             list(APPEND PEANO_COMPILE_DEFS "-D${device_flag}")
         endforeach()
 
         add_custom_command(
-            OUTPUT ${AIE_OBJECT}
+            OUTPUT ${PEANO_OUTPUT}
             COMMAND ${Peano_EXECUTABLE} ${PEANO_FLAGS} ${PEANO_COMPILE_DEFS} -I ${MLIR_AIE_INCLUDE_DIR}
-                    -c ${AIE_SOURCE} -o ${AIE_OBJECT}
-            DEPENDS ${AIE_SOURCE}
-            COMMENT "Compiling ${AIE_SOURCE} for ${KERNEL_NAME} in ${MLIR_OUTPUT}"
+                    -c ${PEANO_SOURCE} -o ${PEANO_OUTPUT}
+            DEPENDS ${PEANO_SOURCE}
+            COMMENT "Compiling ${PEANO_SOURCE} for ${KERNEL_NAME} in ${PEANO_OUTPUT}"
             VERBATIM
         )
-        list(APPEND XCLBIN_DEPS ${AIE_OBJECT})
+        list(APPEND XCLBIN_DEPS ${PEANO_OUTPUT})
     endif()
 
     add_custom_command(
@@ -109,13 +114,17 @@ function(add_aie_iron_kernel TARGET)
     add_custom_command(
         OUTPUT ${PDI_OUTPUT}
         COMMAND bash -c "cp `jq --raw-output \".aie_partition.PDIs.[0].file_name\" ${PARTITION_OUTPUT}` ${PDI_OUTPUT}"
-        DEPENDS ${PARTITION_OUTPUT}
+        DEPENDS ${XCLBIN_OUTPUT} ${PARTITION_OUTPUT}
         COMMENT "Copying PDI for ${KERNEL_NAME} to ${PDI_OUTPUT}"
         VERBATIM
     )
 
     add_custom_target(ggml_hsa_kernel_${KERNEL_NAME} ALL DEPENDS ${PDI_OUTPUT} ${INSTS_OUTPUT})
-    add_dependencies(${TARGET} ggml_hsa_kernel_${KERNEL_NAME})
+    add_dependencies(${TARGET_NAME} ggml_hsa_kernel_${KERNEL_NAME})
+    set_property(TARGET ${TARGET_NAME}
+        APPEND
+        PROPERTY ADDITIONAL_CLEAN_FILES "*.pdi" "core*.elf"
+    )
 
     # copy kernel to install directory
     install(
@@ -127,38 +136,58 @@ function(add_aie_iron_kernel TARGET)
 endfunction()
 
 add_aie_iron_kernel(ggml-hsa
-    KERNEL
+    KERNEL_NAME
         add
+    SOURCE
+        add.py
     DEVICE
         aie2
     KERNEL_SUFFIX
-        "256i32"
+        "256i32-256i32-256i32"
     KERNEL_ARGS
         --dev aie2 --dtype i32 --dims 256
 )
 
 add_aie_iron_kernel(ggml-hsa
-    KERNEL
+    KERNEL_NAME
         add
+    SOURCE
+        add.py
     DEVICE
         aie2
     KERNEL_SUFFIX
-        "256f32"
+        "256f32-256f32-256f32"
     KERNEL_ARGS
         --dev aie2 --dtype f32 --dims 256
 )
 
 add_aie_iron_kernel(ggml-hsa
-    KERNEL
-        mul_mat
+    KERNEL_NAME
+        add
+    SOURCE
+        add.py
     DEVICE
         aie2
     KERNEL_SUFFIX
-        "32x32i16"
+        "768f32-768f32-768f32"
+    KERNEL_ARGS
+        --dev aie2 --dtype f32 --dims 768
+)
+
+add_aie_iron_kernel(ggml-hsa
+    KERNEL_NAME
+        mul_mat
+    SOURCE
+        mul_mat.py
+    DEVICE
+        aie2
+    KERNEL_SUFFIX
+        "32x32i16-32x32i16-32x32i16"
     KERNEL_ARGS
         -M 32 -K 32 -N 32 -m 8 -k 8 -n 8 --dtype_in i16 --dtype_out i16 --n-aie-cols 4 --b-col-maj 0
+
     OBJECT_FILE
         "mm_8x8x8.o"
-    COMPILE_FLAGS
+    COMPILE_ARGS
         BIT_WIDTH=8 i16_i16_ONLY DIM_M=8 DIM_K=8 DIM_N=8
 )

--- a/src/ggml-hsa/kernels/CMakeLists.txt
+++ b/src/ggml-hsa/kernels/CMakeLists.txt
@@ -1,0 +1,225 @@
+include(FindPackageHandleStandardArgs)
+
+find_package(PythonInterp REQUIRED)
+find_package(Python REQUIRED)
+
+# Find Peano
+find_program(Peano_EXECUTABLE
+    NAMES
+        clang++
+    PATHS
+        $ENV{PEANO_INSTALL_DIR}/bin
+    DOC
+        "Path to Peano"
+    NO_DEFAULT_PATH
+    REQUIRED
+)
+find_package_handle_standard_args(Peano REQUIRED_VARS Peano_EXECUTABLE)
+if (Peano_FOUND)
+    mark_as_advanced(Peano_EXECUTABLE)
+endif()
+
+# Find MLIR-AIE
+find_path(MLIR_AIE_INCLUDE_DIR
+    NAMES
+        aie/version.h
+    PATHS
+        $ENV{MLIR_AIE_INSTALL_DIR}/include
+    DOC
+        "Path to MLIR-AIE"
+    NO_DEFAULT_PATH
+    REQUIRED
+)
+mark_as_advanced(MLIR_AIE_INCLUDE_DIR)
+
+# Compile an AIE kernel for a specific device, input/output dimensions and datatypes.
+#
+# This function generates PDI and insts files that are set as dependencies to `TARGET`.
+#
+# Arguments:
+#     TARGET (string): target
+#     KERNEL (string): kernel source file
+#     DEV (string): target device
+#     DTYPE (string): input datatype
+#     DIMS (string): input dimensions
+#
+function(add_aie_kernel TARGET)
+    set(options)
+    set(oneValueArgs KERNEL DEVICE DTYPE DIMS)
+    set(multiValueArgs)
+
+    cmake_parse_arguments(PARSE_ARGV 0 arg
+        "${options}" "${oneValueArgs}" "${multiValueArgs}")
+
+    set(KERNEL_FILE "${CMAKE_CURRENT_SOURCE_DIR}/${arg_KERNEL}.py")
+    set(KERNEL_NAME "${arg_KERNEL}-${arg_DEVICE}-${arg_DIMS}${arg_DTYPE}")
+    set(MLIR_OUTPUT "${KERNEL_NAME}.mlir")
+    set(XCLBIN_OUTPUT "${KERNEL_NAME}.xclbin")
+    set(INSTS_OUTPUT "${KERNEL_NAME}_insts.txt")
+    set(PARTITION_OUTPUT "${KERNEL_NAME}_partition.json")
+    set(PDI_OUTPUT "${KERNEL_NAME}.pdi")
+
+    add_custom_command(
+        OUTPUT ${MLIR_OUTPUT}
+        COMMAND ${PYTHON_EXECUTABLE} ${KERNEL_FILE}
+                --dev ${arg_DEVICE} --dtype ${arg_DTYPE} --dims ${arg_DIMS}
+                > ${MLIR_OUTPUT}
+        DEPENDS ${KERNEL_FILE}
+        BYPRODUCTS ${KERNEL_NAME}.mlir.prj
+        COMMENT "Generating AIE MLIR file for ${KERNEL_NAME} in ${MLIR_OUTPUT}"
+        VERBATIM
+    )
+
+    add_custom_command(
+        OUTPUT ${XCLBIN_OUTPUT} ${INSTS_OUTPUT}
+        COMMAND aiecc.py
+                --aie-generate-cdo --aie-generate-npu --no-compile-host --no-xchesscc --no-xbridge
+                --xclbin-name=${XCLBIN_OUTPUT} --npu-insts-name=${INSTS_OUTPUT}
+                ${MLIR_OUTPUT}
+        DEPENDS ${MLIR_OUTPUT}
+        COMMENT "Generating xclbin for ${KERNEL_NAME} in ${XCLBIN_OUTPUT}"
+        VERBATIM
+    )
+
+    add_custom_command(
+        OUTPUT ${PARTITION_OUTPUT}
+        COMMAND xclbinutil --dump-section AIE_PARTITION:JSON:${PARTITION_OUTPUT} --force --input ${XCLBIN_OUTPUT}
+        DEPENDS ${XCLBIN_OUTPUT}
+        COMMENT "Extracting PDI for ${KERNEL_NAME} with JSON in ${PARTITION_OUTPUT}"
+        VERBATIM
+    )
+
+    add_custom_command(
+        OUTPUT ${PDI_OUTPUT}
+        COMMAND bash -c "cp `jq --raw-output \".aie_partition.PDIs.[0].file_name\" ${PARTITION_OUTPUT}` ${PDI_OUTPUT}"
+        DEPENDS ${PARTITION_OUTPUT}
+        COMMENT "Copying PDI for ${KERNEL_NAME} to ${PDI_OUTPUT}"
+        VERBATIM
+    )
+
+    add_custom_target(ggml_hsa_kernel_${KERNEL_NAME} ALL DEPENDS ${PDI_OUTPUT})
+    add_dependencies(${TARGET} ggml_hsa_kernel_${KERNEL_NAME})
+endfunction()
+
+add_aie_kernel(ggml-hsa
+    KERNEL
+        add
+    DEVICE
+        aie2
+    DTYPE
+        i32
+    DIMS
+        256)
+add_aie_kernel(ggml-hsa
+    KERNEL
+        add
+    DEVICE
+        aie2
+    DTYPE
+        f32
+    DIMS
+        256)
+add_aie_kernel(ggml-hsa
+    KERNEL
+        add
+    DEVICE
+        aie2
+    DTYPE
+        i32
+    DIMS
+        512)
+
+# Compile an AIE kernel for a specific device, input/output dimensions and datatypes.
+#
+# This function generates PDI and insts files that are set as dependencies to `TARGET`.
+#
+# Arguments:
+#     TARGET (string): target
+#     KERNEL (string): kernel source file
+#     DEVICE (string): target device
+#     OBJECT_FILE (string): Peano output file
+#
+function(add_aie_mm_kernel TARGET)
+    set(options)
+    set(oneValueArgs KERNEL DEVICE OBJECT_FILE)
+    set(multiValueArgs KERNEL_ARGS COMPILE_FLAGS)
+
+    cmake_parse_arguments(PARSE_ARGV 0 arg
+        "${options}" "${oneValueArgs}" "${multiValueArgs}")
+
+    set(KERNEL_NAME "${arg_KERNEL}-${arg_DEVICE}-128x128i16")
+    set(KERNEL_FILE "${CMAKE_CURRENT_SOURCE_DIR}/${arg_KERNEL}.py")
+    set(MLIR_OUTPUT "${KERNEL_NAME}.mlir")
+    set(XCLBIN_OUTPUT "${KERNEL_NAME}.xclbin")
+    set(INSTS_OUTPUT "${KERNEL_NAME}_insts.txt")
+    set(PARTITION_OUTPUT "${KERNEL_NAME}_partition.json")
+    set(PDI_OUTPUT "${KERNEL_NAME}.pdi")
+    set(PEANO_WARNING_FLAGS -Wno-parentheses -Wno-attributes -Wno-macro-redefined)
+    set(PEANO_FLAGS -O2 -v -std=c++20 --target=aie2-none-unknown-elf ${PEANO_WARNING_FLAGS} -DNDEBUG)
+    set(AIE_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/${arg_KERNEL}.cc")
+    set(AIE_OBJECT "${CMAKE_CURRENT_BINARY_DIR}/${arg_OBJECT_FILE}")
+
+    set(PEANO_COMPILE_DEFS "")
+    foreach(device_flag ${arg_COMPILE_FLAGS})
+        list(APPEND PEANO_COMPILE_DEFS "-D${device_flag}")
+    endforeach()
+
+    add_custom_command(
+        OUTPUT ${MLIR_OUTPUT}
+        COMMAND ${PYTHON_EXECUTABLE} ${KERNEL_FILE} ${arg_KERNEL_ARGS} > ${MLIR_OUTPUT}
+        DEPENDS ${KERNEL_FILE}
+        BYPRODUCTS ${KERNEL_NAME}.mlir.prj
+        COMMENT "Generating AIE MLIR file for ${KERNEL_NAME} in ${MLIR_OUTPUT}"
+        VERBATIM
+    )
+
+    add_custom_command(
+        OUTPUT ${AIE_OBJECT}
+        COMMAND ${Peano_EXECUTABLE} ${PEANO_FLAGS} ${PEANO_COMPILE_DEFS} -I ${MLIR_AIE_INCLUDE_DIR}
+                -c ${AIE_SOURCE} -o ${AIE_OBJECT}
+        DEPENDS ${AIE_SOURCE}
+        COMMENT "Compiling ${AIE_SOURCE} for ${KERNEL_NAME} in ${MLIR_OUTPUT}"
+        VERBATIM
+    )
+
+    add_custom_command(
+        OUTPUT ${XCLBIN_OUTPUT} ${INSTS_OUTPUT}
+        COMMAND aiecc.py --aie-generate-cdo --aie-generate-npu --no-compile-host --no-xchesscc --no-xbridge
+                --xclbin-name=${XCLBIN_OUTPUT} --npu-insts-name=${INSTS_OUTPUT} ${MLIR_OUTPUT}
+        DEPENDS ${MLIR_OUTPUT} ${AIE_OBJECT}
+        COMMENT "Generating xclbin for ${KERNEL_NAME} in ${XCLBIN_OUTPUT}"
+        VERBATIM
+    )
+
+    add_custom_command(
+        OUTPUT ${PARTITION_OUTPUT}
+        COMMAND xclbinutil --dump-section AIE_PARTITION:JSON:${PARTITION_OUTPUT} --force --input ${XCLBIN_OUTPUT}
+        DEPENDS ${XCLBIN_OUTPUT}
+        COMMENT "Extracting PDI for ${KERNEL_NAME} with JSON in ${PARTITION_OUTPUT}"
+        VERBATIM
+    )
+
+    add_custom_command(
+        OUTPUT ${PDI_OUTPUT}
+        COMMAND bash -c "mv `jq --raw-output \".aie_partition.PDIs.[0].file_name\" ${PARTITION_OUTPUT}` ${PDI_OUTPUT}"
+        DEPENDS ${PARTITION_OUTPUT}
+        COMMENT "Copying PDI for ${KERNEL_NAME} to ${PDI_OUTPUT}"
+        VERBATIM
+    )
+
+    add_custom_target(ggml_hsa_kernel_${KERNEL_NAME} ALL DEPENDS ${PDI_OUTPUT})
+    add_dependencies(${TARGET} ggml_hsa_kernel_${KERNEL_NAME})
+endfunction()
+
+add_aie_mm_kernel(ggml-hsa
+    KERNEL
+        mul_mat
+    DEVICE
+        aie2
+    OBJECT_FILE
+        "mm_64x64x64.o"
+    KERNEL_ARGS
+        -M 512 -K 512 -N 512 -m 64 -k 64 -n 64 --dtype_in i16 --dtype_out i16 --n-aie-cols 2 --b-col-maj 0
+    COMPILE_FLAGS
+        BIT_WIDTH=8 i16_i16_ONLY DIM_M=64 DIM_K=64 DIM_N=64
+)

--- a/src/ggml-hsa/kernels/CMakeLists.txt
+++ b/src/ggml-hsa/kernels/CMakeLists.txt
@@ -204,7 +204,7 @@ function(add_aie_mm_kernel TARGET)
 
     add_custom_command(
         OUTPUT ${PDI_OUTPUT}
-        COMMAND bash -c "mv `jq --raw-output \".aie_partition.PDIs.[0].file_name\" ${PARTITION_OUTPUT}` ${PDI_OUTPUT}"
+        COMMAND bash -c "cp `jq --raw-output \".aie_partition.PDIs.[0].file_name\" ${PARTITION_OUTPUT}` ${PDI_OUTPUT}"
         DEPENDS ${PARTITION_OUTPUT}
         COMMENT "Copying PDI for ${KERNEL_NAME} to ${PDI_OUTPUT}"
         VERBATIM

--- a/src/ggml-hsa/kernels/CMakeLists.txt
+++ b/src/ggml-hsa/kernels/CMakeLists.txt
@@ -220,11 +220,11 @@ add_aie_mm_kernel(ggml-hsa
     DEVICE
         aie2
     KERNEL_SUFFIX
-        "128x128i16"
+        "32x32i16"
     OBJECT_FILE
         "mm_8x8x8.o"
     KERNEL_ARGS
-        -M 128 -K 128 -N 128 -m 8 -k 8 -n 8 --dtype_in i16 --dtype_out i16 --n-aie-cols 2 --b-col-maj 0
+        -M 32 -K 32 -N 32 -m 8 -k 8 -n 8 --dtype_in i16 --dtype_out i16 --n-aie-cols 4 --b-col-maj 0
     COMPILE_FLAGS
         BIT_WIDTH=8 i16_i16_ONLY DIM_M=8 DIM_K=8 DIM_N=8
 )

--- a/src/ggml-hsa/kernels/CMakeLists.txt
+++ b/src/ggml-hsa/kernels/CMakeLists.txt
@@ -1,7 +1,6 @@
 include(FindPackageHandleStandardArgs)
 
-find_package(PythonInterp REQUIRED)
-find_package(Python REQUIRED)
+find_package(Python REQUIRED COMPONENTS Interpreter)
 
 # Find Peano
 find_program(Peano_EXECUTABLE
@@ -42,7 +41,7 @@ mark_as_advanced(MLIR_AIE_INCLUDE_DIR)
 #     DEVICE (string): target device
 #     OBJECT_FILE (string): Peano output file
 #
-function(add_aie_mm_kernel TARGET)
+function(add_aie_kernel TARGET)
     set(options)
     set(oneValueArgs KERNEL KERNEL_SUFFIX DEVICE OBJECT_FILE)
     set(multiValueArgs KERNEL_ARGS COMPILE_FLAGS)
@@ -60,7 +59,7 @@ function(add_aie_mm_kernel TARGET)
 
     add_custom_command(
         OUTPUT ${MLIR_OUTPUT}
-        COMMAND ${PYTHON_EXECUTABLE} ${KERNEL_FILE} ${arg_KERNEL_ARGS} > ${MLIR_OUTPUT}
+        COMMAND ${Python_EXECUTABLE} ${KERNEL_FILE} ${arg_KERNEL_ARGS} > ${MLIR_OUTPUT}
         DEPENDS ${KERNEL_FILE}
         BYPRODUCTS ${KERNEL_NAME}.mlir.prj
         COMMENT "Generating AIE MLIR file for ${KERNEL_NAME} in ${MLIR_OUTPUT}"
@@ -119,7 +118,7 @@ function(add_aie_mm_kernel TARGET)
     add_dependencies(${TARGET} ggml_hsa_kernel_${KERNEL_NAME})
 endfunction()
 
-add_aie_mm_kernel(ggml-hsa
+add_aie_kernel(ggml-hsa
     KERNEL
         add
     DEVICE
@@ -130,7 +129,7 @@ add_aie_mm_kernel(ggml-hsa
         --dev aie2 --dtype i32 --dims 256
 )
 
-add_aie_mm_kernel(ggml-hsa
+add_aie_kernel(ggml-hsa
     KERNEL
         add
     DEVICE
@@ -141,7 +140,7 @@ add_aie_mm_kernel(ggml-hsa
         --dev aie2 --dtype f32 --dims 256
 )
 
-add_aie_mm_kernel(ggml-hsa
+add_aie_kernel(ggml-hsa
     KERNEL
         mul_mat
     DEVICE

--- a/src/ggml-hsa/kernels/CMakeLists.txt
+++ b/src/ggml-hsa/kernels/CMakeLists.txt
@@ -39,20 +39,20 @@ mark_as_advanced(MLIR_AIE_INCLUDE_DIR)
 # Arguments:
 #     TARGET (string): target
 #     KERNEL (string): kernel source file
-#     DEV (string): target device
-#     DTYPE (string): input datatype
-#     DIMS (string): input dimensions
+#     DEVICE (string): target device
+#     INPUT_DTYPE (string): input datatype
+#     INPUT_DIMS (string): input dimensions
 #
 function(add_aie_kernel TARGET)
     set(options)
-    set(oneValueArgs KERNEL DEVICE DTYPE DIMS)
+    set(oneValueArgs KERNEL DEVICE INPUT_DTYPE INPUT_DIMS)
     set(multiValueArgs)
 
     cmake_parse_arguments(PARSE_ARGV 0 arg
         "${options}" "${oneValueArgs}" "${multiValueArgs}")
 
     set(KERNEL_FILE "${CMAKE_CURRENT_SOURCE_DIR}/${arg_KERNEL}.py")
-    set(KERNEL_NAME "${arg_KERNEL}-${arg_DEVICE}-${arg_DIMS}${arg_DTYPE}")
+    set(KERNEL_NAME "${arg_KERNEL}-${arg_DEVICE}-${arg_INPUT_DIMS}${arg_INPUT_DTYPE}")
     set(MLIR_OUTPUT "${KERNEL_NAME}.mlir")
     set(XCLBIN_OUTPUT "${KERNEL_NAME}.xclbin")
     set(INSTS_OUTPUT "${KERNEL_NAME}_insts.txt")
@@ -62,7 +62,7 @@ function(add_aie_kernel TARGET)
     add_custom_command(
         OUTPUT ${MLIR_OUTPUT}
         COMMAND ${PYTHON_EXECUTABLE} ${KERNEL_FILE}
-                --dev ${arg_DEVICE} --dtype ${arg_DTYPE} --dims ${arg_DIMS}
+                --dev ${arg_DEVICE} --dtype ${arg_INPUT_DTYPE} --dims ${arg_INPUT_DIMS}
                 > ${MLIR_OUTPUT}
         DEPENDS ${KERNEL_FILE}
         BYPRODUCTS ${KERNEL_NAME}.mlir.prj
@@ -106,28 +106,31 @@ add_aie_kernel(ggml-hsa
         add
     DEVICE
         aie2
-    DTYPE
+    INPUT_DTYPE
         i32
-    DIMS
-        256)
+    INPUT_DIMS
+        256
+)
 add_aie_kernel(ggml-hsa
     KERNEL
         add
     DEVICE
         aie2
-    DTYPE
+    INPUT_DTYPE
         f32
-    DIMS
-        256)
+    INPUT_DIMS
+        256
+)
 add_aie_kernel(ggml-hsa
     KERNEL
         add
     DEVICE
         aie2
-    DTYPE
+    INPUT_DTYPE
         i32
-    DIMS
-        512)
+    INPUT_DIMS
+        512
+)
 
 # Compile an AIE kernel for a specific device, input/output dimensions and datatypes.
 #
@@ -214,10 +217,10 @@ endfunction()
 add_aie_mm_kernel(ggml-hsa
     KERNEL
         mul_mat
-    KERNEL_SUFFIX
-        "128x128x128i16"
     DEVICE
         aie2
+    KERNEL_SUFFIX
+        "128x128i16"
     OBJECT_FILE
         "mm_8x8x8.o"
     KERNEL_ARGS

--- a/src/ggml-hsa/kernels/CMakeLists.txt
+++ b/src/ggml-hsa/kernels/CMakeLists.txt
@@ -40,106 +40,6 @@ mark_as_advanced(MLIR_AIE_INCLUDE_DIR)
 #     TARGET (string): target
 #     KERNEL (string): kernel source file
 #     DEVICE (string): target device
-#     INPUT_DTYPE (string): input datatype
-#     INPUT_DIMS (string): input dimensions
-#
-function(add_aie_kernel TARGET)
-    set(options)
-    set(oneValueArgs KERNEL DEVICE INPUT_DTYPE INPUT_DIMS)
-    set(multiValueArgs)
-
-    cmake_parse_arguments(PARSE_ARGV 0 arg
-        "${options}" "${oneValueArgs}" "${multiValueArgs}")
-
-    set(KERNEL_FILE "${CMAKE_CURRENT_SOURCE_DIR}/${arg_KERNEL}.py")
-    set(KERNEL_NAME "${arg_KERNEL}-${arg_DEVICE}-${arg_INPUT_DIMS}${arg_INPUT_DTYPE}")
-    set(MLIR_OUTPUT "${KERNEL_NAME}.mlir")
-    set(XCLBIN_OUTPUT "${KERNEL_NAME}.xclbin")
-    set(INSTS_OUTPUT "${KERNEL_NAME}_insts.txt")
-    set(PARTITION_OUTPUT "${KERNEL_NAME}_partition.json")
-    set(PDI_OUTPUT "${KERNEL_NAME}.pdi")
-
-    add_custom_command(
-        OUTPUT ${MLIR_OUTPUT}
-        COMMAND ${PYTHON_EXECUTABLE} ${KERNEL_FILE}
-                --dev ${arg_DEVICE} --dtype ${arg_INPUT_DTYPE} --dims ${arg_INPUT_DIMS}
-                > ${MLIR_OUTPUT}
-        DEPENDS ${KERNEL_FILE}
-        BYPRODUCTS ${KERNEL_NAME}.mlir.prj
-        COMMENT "Generating AIE MLIR file for ${KERNEL_NAME} in ${MLIR_OUTPUT}"
-        VERBATIM
-    )
-
-    add_custom_command(
-        OUTPUT ${XCLBIN_OUTPUT} ${INSTS_OUTPUT}
-        COMMAND aiecc.py
-                --aie-generate-cdo --aie-generate-npu --no-compile-host --no-xchesscc --no-xbridge
-                --xclbin-name=${XCLBIN_OUTPUT} --npu-insts-name=${INSTS_OUTPUT}
-                ${MLIR_OUTPUT}
-        DEPENDS ${MLIR_OUTPUT}
-        COMMENT "Generating xclbin for ${KERNEL_NAME} in ${XCLBIN_OUTPUT}"
-        VERBATIM
-    )
-
-    add_custom_command(
-        OUTPUT ${PARTITION_OUTPUT}
-        COMMAND xclbinutil --dump-section AIE_PARTITION:JSON:${PARTITION_OUTPUT} --force --input ${XCLBIN_OUTPUT}
-        DEPENDS ${XCLBIN_OUTPUT}
-        COMMENT "Extracting PDI for ${KERNEL_NAME} with JSON in ${PARTITION_OUTPUT}"
-        VERBATIM
-    )
-
-    add_custom_command(
-        OUTPUT ${PDI_OUTPUT}
-        COMMAND bash -c "cp `jq --raw-output \".aie_partition.PDIs.[0].file_name\" ${PARTITION_OUTPUT}` ${PDI_OUTPUT}"
-        DEPENDS ${PARTITION_OUTPUT}
-        COMMENT "Copying PDI for ${KERNEL_NAME} to ${PDI_OUTPUT}"
-        VERBATIM
-    )
-
-    add_custom_target(ggml_hsa_kernel_${KERNEL_NAME} ALL DEPENDS ${PDI_OUTPUT} ${INSTS_OUTPUT})
-    add_dependencies(${TARGET} ggml_hsa_kernel_${KERNEL_NAME})
-endfunction()
-
-add_aie_kernel(ggml-hsa
-    KERNEL
-        add
-    DEVICE
-        aie2
-    INPUT_DTYPE
-        i32
-    INPUT_DIMS
-        256
-)
-add_aie_kernel(ggml-hsa
-    KERNEL
-        add
-    DEVICE
-        aie2
-    INPUT_DTYPE
-        f32
-    INPUT_DIMS
-        256
-)
-add_aie_kernel(ggml-hsa
-    KERNEL
-        add
-    DEVICE
-        aie2
-    INPUT_DTYPE
-        i32
-    INPUT_DIMS
-        512
-)
-
-# Compile an AIE kernel for a specific device, input/output dimensions and datatypes.
-#
-# This function generates PDI and insts files that are set as dependencies to `TARGET`.
-#
-# Arguments:
-#     TARGET (string): target
-#     KERNEL (string): kernel source file
-#     DEVICE (string): target device
 #     OBJECT_FILE (string): Peano output file
 #
 function(add_aie_mm_kernel TARGET)
@@ -157,15 +57,6 @@ function(add_aie_mm_kernel TARGET)
     set(INSTS_OUTPUT "${KERNEL_NAME}_insts.txt")
     set(PARTITION_OUTPUT "${KERNEL_NAME}_partition.json")
     set(PDI_OUTPUT "${KERNEL_NAME}.pdi")
-    set(PEANO_WARNING_FLAGS -Wno-parentheses -Wno-attributes -Wno-macro-redefined)
-    set(PEANO_FLAGS -O2 -v -std=c++20 --target=aie2-none-unknown-elf ${PEANO_WARNING_FLAGS} -DNDEBUG)
-    set(AIE_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/${arg_KERNEL}.cc")
-    set(AIE_OBJECT "${CMAKE_CURRENT_BINARY_DIR}/${arg_OBJECT_FILE}")
-
-    set(PEANO_COMPILE_DEFS "")
-    foreach(device_flag ${arg_COMPILE_FLAGS})
-        list(APPEND PEANO_COMPILE_DEFS "-D${device_flag}")
-    endforeach()
 
     add_custom_command(
         OUTPUT ${MLIR_OUTPUT}
@@ -176,20 +67,34 @@ function(add_aie_mm_kernel TARGET)
         VERBATIM
     )
 
-    add_custom_command(
-        OUTPUT ${AIE_OBJECT}
-        COMMAND ${Peano_EXECUTABLE} ${PEANO_FLAGS} ${PEANO_COMPILE_DEFS} -I ${MLIR_AIE_INCLUDE_DIR}
-                -c ${AIE_SOURCE} -o ${AIE_OBJECT}
-        DEPENDS ${AIE_SOURCE}
-        COMMENT "Compiling ${AIE_SOURCE} for ${KERNEL_NAME} in ${MLIR_OUTPUT}"
-        VERBATIM
-    )
+    set(XCLBIN_DEPS ${MLIR_OUTPUT})
+    if (DEFINED arg_OBJECT_FILE)
+        set(PEANO_WARNING_FLAGS -Wno-parentheses -Wno-attributes -Wno-macro-redefined)
+        set(PEANO_FLAGS -O2 -v -std=c++20 --target=aie2-none-unknown-elf ${PEANO_WARNING_FLAGS} -DNDEBUG)
+        set(AIE_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/${arg_KERNEL}.cc")
+        set(AIE_OBJECT "${CMAKE_CURRENT_BINARY_DIR}/${arg_OBJECT_FILE}")
+
+        set(PEANO_COMPILE_DEFS "")
+        foreach(device_flag ${arg_COMPILE_FLAGS})
+            list(APPEND PEANO_COMPILE_DEFS "-D${device_flag}")
+        endforeach()
+
+        add_custom_command(
+            OUTPUT ${AIE_OBJECT}
+            COMMAND ${Peano_EXECUTABLE} ${PEANO_FLAGS} ${PEANO_COMPILE_DEFS} -I ${MLIR_AIE_INCLUDE_DIR}
+                    -c ${AIE_SOURCE} -o ${AIE_OBJECT}
+            DEPENDS ${AIE_SOURCE}
+            COMMENT "Compiling ${AIE_SOURCE} for ${KERNEL_NAME} in ${MLIR_OUTPUT}"
+            VERBATIM
+        )
+        list(APPEND XCLBIN_DEPS ${AIE_OBJECT})
+    endif()
 
     add_custom_command(
         OUTPUT ${XCLBIN_OUTPUT} ${INSTS_OUTPUT}
         COMMAND aiecc.py --aie-generate-cdo --aie-generate-npu --no-compile-host --no-xchesscc --no-xbridge
                 --xclbin-name=${XCLBIN_OUTPUT} --npu-insts-name=${INSTS_OUTPUT} ${MLIR_OUTPUT}
-        DEPENDS ${MLIR_OUTPUT} ${AIE_OBJECT}
+        DEPENDS ${XCLBIN_DEPS}
         COMMENT "Generating xclbin for ${KERNEL_NAME} in ${XCLBIN_OUTPUT}"
         VERBATIM
     )
@@ -216,15 +121,37 @@ endfunction()
 
 add_aie_mm_kernel(ggml-hsa
     KERNEL
+        add
+    DEVICE
+        aie2
+    KERNEL_SUFFIX
+        "256i32"
+    KERNEL_ARGS
+        --dev aie2 --dtype i32 --dims 256
+)
+
+add_aie_mm_kernel(ggml-hsa
+    KERNEL
+        add
+    DEVICE
+        aie2
+    KERNEL_SUFFIX
+        "256f32"
+    KERNEL_ARGS
+        --dev aie2 --dtype f32 --dims 256
+)
+
+add_aie_mm_kernel(ggml-hsa
+    KERNEL
         mul_mat
     DEVICE
         aie2
     KERNEL_SUFFIX
         "32x32i16"
-    OBJECT_FILE
-        "mm_8x8x8.o"
     KERNEL_ARGS
         -M 32 -K 32 -N 32 -m 8 -k 8 -n 8 --dtype_in i16 --dtype_out i16 --n-aie-cols 4 --b-col-maj 0
+    OBJECT_FILE
+        "mm_8x8x8.o"
     COMPILE_FLAGS
         BIT_WIDTH=8 i16_i16_ONLY DIM_M=8 DIM_K=8 DIM_N=8
 )

--- a/src/ggml-hsa/kernels/CMakeLists.txt
+++ b/src/ggml-hsa/kernels/CMakeLists.txt
@@ -31,7 +31,7 @@ find_path(MLIR_AIE_INCLUDE_DIR
 )
 mark_as_advanced(MLIR_AIE_INCLUDE_DIR)
 
-# Compile an AIE kernel for a specific device, input/output dimensions and datatypes.
+# Compile an AIE kernel using IRON.
 #
 # This function generates PDI and insts files that are set as dependencies to `TARGET`.
 #
@@ -41,7 +41,7 @@ mark_as_advanced(MLIR_AIE_INCLUDE_DIR)
 #     DEVICE (string): target device
 #     OBJECT_FILE (string): Peano output file
 #
-function(add_aie_kernel TARGET)
+function(add_aie_iron_kernel TARGET)
     set(options)
     set(oneValueArgs KERNEL KERNEL_SUFFIX DEVICE OBJECT_FILE)
     set(multiValueArgs KERNEL_ARGS COMPILE_FLAGS)
@@ -69,7 +69,7 @@ function(add_aie_kernel TARGET)
     set(XCLBIN_DEPS ${MLIR_OUTPUT})
     if (DEFINED arg_OBJECT_FILE)
         set(PEANO_WARNING_FLAGS -Wno-parentheses -Wno-attributes -Wno-macro-redefined)
-        set(PEANO_FLAGS -O2 -v -std=c++20 --target=aie2-none-unknown-elf ${PEANO_WARNING_FLAGS} -DNDEBUG)
+        set(PEANO_FLAGS -O2 -std=c++20 --target=aie2-none-unknown-elf ${PEANO_WARNING_FLAGS} -DNDEBUG)
         set(AIE_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/${arg_KERNEL}.cc")
         set(AIE_OBJECT "${CMAKE_CURRENT_BINARY_DIR}/${arg_OBJECT_FILE}")
 
@@ -116,9 +116,15 @@ function(add_aie_kernel TARGET)
 
     add_custom_target(ggml_hsa_kernel_${KERNEL_NAME} ALL DEPENDS ${PDI_OUTPUT} ${INSTS_OUTPUT})
     add_dependencies(${TARGET} ggml_hsa_kernel_${KERNEL_NAME})
+
+    # copy kernel to install directory
+    install(
+        FILES ${CMAKE_CURRENT_BINARY_DIR}/${PDI_OUTPUT}
+        DESTINATION lib/kernels/
+    )
 endfunction()
 
-add_aie_kernel(ggml-hsa
+add_aie_iron_kernel(ggml-hsa
     KERNEL
         add
     DEVICE
@@ -129,7 +135,7 @@ add_aie_kernel(ggml-hsa
         --dev aie2 --dtype i32 --dims 256
 )
 
-add_aie_kernel(ggml-hsa
+add_aie_iron_kernel(ggml-hsa
     KERNEL
         add
     DEVICE
@@ -140,7 +146,7 @@ add_aie_kernel(ggml-hsa
         --dev aie2 --dtype f32 --dims 256
 )
 
-add_aie_kernel(ggml-hsa
+add_aie_iron_kernel(ggml-hsa
     KERNEL
         mul_mat
     DEVICE

--- a/src/ggml-hsa/kernels/CMakeLists.txt
+++ b/src/ggml-hsa/kernels/CMakeLists.txt
@@ -119,7 +119,9 @@ function(add_aie_iron_kernel TARGET)
 
     # copy kernel to install directory
     install(
-        FILES ${CMAKE_CURRENT_BINARY_DIR}/${PDI_OUTPUT}
+        FILES
+            ${CMAKE_CURRENT_BINARY_DIR}/${PDI_OUTPUT}
+            ${CMAKE_CURRENT_BINARY_DIR}/${INSTS_OUTPUT}
         DESTINATION lib/kernels/
     )
 endfunction()

--- a/src/ggml-hsa/kernels/CMakeLists.txt
+++ b/src/ggml-hsa/kernels/CMakeLists.txt
@@ -97,7 +97,7 @@ function(add_aie_kernel TARGET)
         VERBATIM
     )
 
-    add_custom_target(ggml_hsa_kernel_${KERNEL_NAME} ALL DEPENDS ${PDI_OUTPUT})
+    add_custom_target(ggml_hsa_kernel_${KERNEL_NAME} ALL DEPENDS ${PDI_OUTPUT} ${INSTS_OUTPUT})
     add_dependencies(${TARGET} ggml_hsa_kernel_${KERNEL_NAME})
 endfunction()
 
@@ -141,13 +141,13 @@ add_aie_kernel(ggml-hsa
 #
 function(add_aie_mm_kernel TARGET)
     set(options)
-    set(oneValueArgs KERNEL DEVICE OBJECT_FILE)
+    set(oneValueArgs KERNEL KERNEL_SUFFIX DEVICE OBJECT_FILE)
     set(multiValueArgs KERNEL_ARGS COMPILE_FLAGS)
 
     cmake_parse_arguments(PARSE_ARGV 0 arg
         "${options}" "${oneValueArgs}" "${multiValueArgs}")
 
-    set(KERNEL_NAME "${arg_KERNEL}-${arg_DEVICE}-128x128i16")
+    set(KERNEL_NAME "${arg_KERNEL}-${arg_DEVICE}-${arg_KERNEL_SUFFIX}")
     set(KERNEL_FILE "${CMAKE_CURRENT_SOURCE_DIR}/${arg_KERNEL}.py")
     set(MLIR_OUTPUT "${KERNEL_NAME}.mlir")
     set(XCLBIN_OUTPUT "${KERNEL_NAME}.xclbin")
@@ -207,19 +207,21 @@ function(add_aie_mm_kernel TARGET)
         VERBATIM
     )
 
-    add_custom_target(ggml_hsa_kernel_${KERNEL_NAME} ALL DEPENDS ${PDI_OUTPUT})
+    add_custom_target(ggml_hsa_kernel_${KERNEL_NAME} ALL DEPENDS ${PDI_OUTPUT} ${INSTS_OUTPUT})
     add_dependencies(${TARGET} ggml_hsa_kernel_${KERNEL_NAME})
 endfunction()
 
 add_aie_mm_kernel(ggml-hsa
     KERNEL
         mul_mat
+    KERNEL_SUFFIX
+        "128x128x128i16"
     DEVICE
         aie2
     OBJECT_FILE
-        "mm_64x64x64.o"
+        "mm_8x8x8.o"
     KERNEL_ARGS
-        -M 512 -K 512 -N 512 -m 64 -k 64 -n 64 --dtype_in i16 --dtype_out i16 --n-aie-cols 2 --b-col-maj 0
+        -M 128 -K 128 -N 128 -m 8 -k 8 -n 8 --dtype_in i16 --dtype_out i16 --n-aie-cols 2 --b-col-maj 0
     COMPILE_FLAGS
-        BIT_WIDTH=8 i16_i16_ONLY DIM_M=64 DIM_K=64 DIM_N=64
+        BIT_WIDTH=8 i16_i16_ONLY DIM_M=8 DIM_K=8 DIM_N=8
 )

--- a/src/ggml-hsa/kernels/mul_mat.cc
+++ b/src/ggml-hsa/kernels/mul_mat.cc
@@ -1,0 +1,766 @@
+//===- mm.cc ----------------------------------------------000---*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2024, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#define NOCPP
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <type_traits>
+
+#define REL_WRITE 0
+#define REL_READ 1
+
+#include <aie_api/aie.hpp>
+
+#include "zero.cc"
+
+template <typename T_in, typename T_out, int rowA, int colA, int colB>
+static inline void matmul_scalar(T_in *a, T_in *b, T_out *c) {
+  event0();
+  for (int row = 0; row < rowA; row++) {
+    for (int col = 0; col < colB; col++) {
+      T_out running_sum = 0;
+      for (int i = 0; i < colA; i++) {
+        running_sum += a[row * colA + i] * b[i * colB + col];
+      }
+      c[row * colB + col] += running_sum;
+    }
+  }
+  event1();
+}
+
+/* Blocked MatMul kernel (vectorized) utilizing the aie::mmul class.
+ * The matrices are assumed to be pre-tiled with the following shapes
+ * for the aie:mmul class: A => rxs, B => sxt, C => rxt.
+ *
+ * The matrix dimensions of the kernel are defined by rowA, colA and colB.
+ * In this particular kernel we expand the aie::mmul two times in each
+ * input matrices A (in 'm' dimension, or rowA) and B (in 'n' dimension, or
+ * ColB), leading to a 2x2 expansion in output matrix C (see C00, C01, C10, C11
+ * below). This expansion helps with accumulator registers usage, which leads in
+ * attaining high kernel efficiency (SIMD utilization).
+ *
+ * Data within each tile (rxs, sxt and rxt) are assumed to be in row-major
+ * order. Also, the entire tiles themselves are stored in row-major order, as
+ * shown in the example below for matrix A:
+ *
+ *      <-s->
+ *    _  ________________________
+ * 	  r |  1 |  2 |  3 | ...
+ * 	  _ |____|____|____|
+ * 	    |  x | x+1| x+2| ...
+ * 	    |____|____|____|
+ * 	    |.
+ * 	    |.
+ * 	    |.
+ */
+template <typename T_in, typename T_out, unsigned rowA, unsigned colA,
+          unsigned colB, unsigned r, unsigned s, unsigned t>
+static inline void matmul_vectorized_2x2_mmul(const T_in *__restrict pA,
+                                              const T_in *__restrict pB,
+                                              T_out *__restrict pC) {
+
+  using MMUL = aie::mmul<r, s, t, T_in, T_in, accauto>;
+
+  event0();
+
+  for (unsigned z = 0; z < rowA; z += 2)
+    chess_prepare_for_pipelining chess_loop_range(4, ) {
+      T_out *__restrict pC1 = pC + (z * colB + 0) * MMUL::size_C;
+      T_out *__restrict pC2 = pC + ((z + 1) * colB + 0) * MMUL::size_C;
+
+      for (unsigned j = 0; j < colB; j += 2)
+#ifdef OPT_PERF_ENABLED
+        chess_flatten_loop
+#endif
+        {
+          const T_in *__restrict pA1 = pA + (z * colA + 0) * MMUL::size_A;
+          const T_in *__restrict pA2 = pA + ((z + 1) * colA + 0) * MMUL::size_A;
+          const T_in *__restrict pB1 = pB + (0 * colB + j) * MMUL::size_B;
+          const T_in *__restrict pB2 = pB + (0 * colB + (j + 1)) * MMUL::size_B;
+
+          aie::vector<T_in, MMUL::size_A> A0 = aie::load_v<MMUL::size_A>(pA1);
+          pA1 += MMUL::size_A;
+          aie::vector<T_in, MMUL::size_A> A1 = aie::load_v<MMUL::size_A>(pA2);
+          pA2 += MMUL::size_A;
+          aie::vector<T_in, MMUL::size_B> B0 = aie::load_v<MMUL::size_B>(pB1);
+          pB1 += MMUL::size_B * colB;
+          aie::vector<T_in, MMUL::size_B> B1 = aie::load_v<MMUL::size_B>(pB2);
+          pB2 += MMUL::size_B * colB;
+
+          // Load partial results from C buffer for accumulation in-place. The
+          // zero.cc function handles the zeroing of data when a new
+          // accumulation is needed (after the 'K' reduction dimension)
+          aie::vector<T_out, MMUL::size_C> acc_C00 =
+              aie::load_v<MMUL::size_C>(pC1);
+          aie::vector<T_out, MMUL::size_C> acc_C01 =
+              aie::load_v<MMUL::size_C>(pC1 + MMUL::size_C);
+          aie::vector<T_out, MMUL::size_C> acc_C10 =
+              aie::load_v<MMUL::size_C>(pC2);
+          aie::vector<T_out, MMUL::size_C> acc_C11 =
+              aie::load_v<MMUL::size_C>(pC2 + MMUL::size_C);
+
+          MMUL C00(acc_C00);
+          MMUL C01(acc_C01);
+          MMUL C10(acc_C10);
+          MMUL C11(acc_C11);
+
+          C00.mac(A0, B0);
+          C01.mac(A0, B1);
+          C10.mac(A1, B0);
+          C11.mac(A1, B1);
+
+          for (unsigned i = 1; i < colA; ++i)
+#ifdef OPT_PERF_ENABLED
+            chess_flatten_loop
+#endif
+            {
+              A0 = aie::load_v<MMUL::size_A>(pA1);
+              pA1 += MMUL::size_A;
+              A1 = aie::load_v<MMUL::size_A>(pA2);
+              pA2 += MMUL::size_A;
+              B0 = aie::load_v<MMUL::size_B>(pB1);
+              pB1 += MMUL::size_B * colB;
+              B1 = aie::load_v<MMUL::size_B>(pB2);
+              pB2 += MMUL::size_B * colB;
+
+              C00.mac(A0, B0);
+              C01.mac(A0, B1);
+              C10.mac(A1, B0);
+              C11.mac(A1, B1);
+            }
+
+          // TODO make shift right here to keep most significat bits
+          // when lowering the output
+          // example below shows how to shift right 10 bits
+          // #define SHIFT 10
+          // aie::store_v(pC1, C00.template to_vector<T_out>(SHIFT));
+          aie::store_v(pC1, C00.template to_vector<T_out>());
+          pC1 += MMUL::size_C;
+          aie::store_v(pC1, C01.template to_vector<T_out>());
+          pC1 += MMUL::size_C;
+          aie::store_v(pC2, C10.template to_vector<T_out>());
+          pC2 += MMUL::size_C;
+          aie::store_v(pC2, C11.template to_vector<T_out>());
+          pC2 += MMUL::size_C;
+        }
+    }
+
+  event1();
+}
+
+/* Similar to the kernel above, but we expand matrix A (in 'm' dimension, or
+ * rowA) 4 times, while matrix B is expanded 2 times (in 'n' dimension, or
+ * ColB). This is very helpful in attaining high kernel efficiency for some
+ * precisions (e.g., int8)
+ */
+template <typename T_in, typename T_out, unsigned rowA, unsigned colA,
+          unsigned colB, unsigned r, unsigned s, unsigned t>
+static inline void matmul_vectorized_4x2_mmul(const T_in *__restrict pA,
+                                              const T_in *__restrict pB,
+                                              T_out *__restrict pC) {
+
+  using MMUL = aie::mmul<r, s, t, T_in, T_in, accauto>;
+
+  event0();
+
+  for (unsigned z = 0; z < rowA; z += 4)
+    chess_prepare_for_pipelining chess_loop_range(4, ) {
+      T_out *__restrict pC1 = pC + (z * colB + 0) * MMUL::size_C;
+      T_out *__restrict pC2 = pC + ((z + 1) * colB + 0) * MMUL::size_C;
+      T_out *__restrict pC3 = pC + ((z + 2) * colB + 0) * MMUL::size_C;
+      T_out *__restrict pC4 = pC + ((z + 3) * colB + 0) * MMUL::size_C;
+
+      for (unsigned j = 0; j < colB; j += 2)
+#ifdef OPT_PERF_ENABLED
+        chess_flatten_loop
+#endif
+        {
+          const T_in *__restrict pA1 = pA + (z * colA + 0) * MMUL::size_A;
+          const T_in *__restrict pA2 = pA + ((z + 1) * colA + 0) * MMUL::size_A;
+          const T_in *__restrict pA3 = pA + ((z + 2) * colA + 0) * MMUL::size_A;
+          const T_in *__restrict pA4 = pA + ((z + 3) * colA + 0) * MMUL::size_A;
+
+          const T_in *__restrict pB1 = pB + (0 * colB + j) * MMUL::size_B;
+          const T_in *__restrict pB2 = pB + (0 * colB + (j + 1)) * MMUL::size_B;
+
+          aie::vector<T_in, MMUL::size_A> A01 = aie::load_v<MMUL::size_A>(pA1);
+          pA1 += MMUL::size_A;
+          aie::vector<T_in, MMUL::size_A> A11 = aie::load_v<MMUL::size_A>(pA2);
+          pA2 += MMUL::size_A;
+          aie::vector<T_in, MMUL::size_A> A21 = aie::load_v<MMUL::size_A>(pA3);
+          pA3 += MMUL::size_A;
+          aie::vector<T_in, MMUL::size_A> A31 = aie::load_v<MMUL::size_A>(pA4);
+          pA4 += MMUL::size_A;
+          aie::vector<T_in, MMUL::size_B> B01 = aie::load_v<MMUL::size_B>(pB1);
+          pB1 += (MMUL::size_B * colB);
+          aie::vector<T_in, MMUL::size_B> B11 = aie::load_v<MMUL::size_B>(pB2);
+          pB2 += (MMUL::size_B * colB);
+
+          aie::vector<T_out, MMUL::size_C> acc_C00 =
+              aie::load_v<MMUL::size_C>(pC1);
+          aie::vector<T_out, MMUL::size_C> acc_C01 =
+              aie::load_v<MMUL::size_C>(pC1 + MMUL::size_C);
+          aie::vector<T_out, MMUL::size_C> acc_C10 =
+              aie::load_v<MMUL::size_C>(pC2);
+          aie::vector<T_out, MMUL::size_C> acc_C11 =
+              aie::load_v<MMUL::size_C>(pC2 + MMUL::size_C);
+          aie::vector<T_out, MMUL::size_C> acc_C20 =
+              aie::load_v<MMUL::size_C>(pC3);
+          aie::vector<T_out, MMUL::size_C> acc_C21 =
+              aie::load_v<MMUL::size_C>(pC3 + MMUL::size_C);
+          aie::vector<T_out, MMUL::size_C> acc_C30 =
+              aie::load_v<MMUL::size_C>(pC4);
+          aie::vector<T_out, MMUL::size_C> acc_C31 =
+              aie::load_v<MMUL::size_C>(pC4 + MMUL::size_C);
+
+          MMUL C00(acc_C00);
+          MMUL C01(acc_C01);
+          MMUL C10(acc_C10);
+          MMUL C11(acc_C11);
+          MMUL C20(acc_C20);
+          MMUL C21(acc_C21);
+          MMUL C30(acc_C30);
+          MMUL C31(acc_C31);
+
+          C00.mac(A01, B01);
+          C01.mac(A01, B11);
+          C10.mac(A11, B01);
+          C11.mac(A11, B11);
+          C20.mac(A21, B01);
+          C21.mac(A21, B11);
+          C30.mac(A31, B01);
+          C31.mac(A31, B11);
+
+          for (unsigned i = 1; i < colA; i += 1)
+#ifdef OPT_PERF_ENABLED
+            chess_flatten_loop
+#endif
+            {
+              A01 = aie::load_v<MMUL::size_A>(pA1);
+              pA1 += MMUL::size_A;
+              A11 = aie::load_v<MMUL::size_A>(pA2);
+              pA2 += MMUL::size_A;
+              A21 = aie::load_v<MMUL::size_A>(pA3);
+              pA3 += MMUL::size_A;
+              A31 = aie::load_v<MMUL::size_A>(pA4);
+              pA4 += MMUL::size_A;
+              B01 = aie::load_v<MMUL::size_B>(pB1);
+              pB1 += (MMUL::size_B * colB);
+              B11 = aie::load_v<MMUL::size_B>(pB2);
+              pB2 += (MMUL::size_B * colB);
+
+              C00.mac(A01, B01);
+              C01.mac(A01, B11);
+              C10.mac(A11, B01);
+              C11.mac(A11, B11);
+              C20.mac(A21, B01);
+              C21.mac(A21, B11);
+              C30.mac(A31, B01);
+              C31.mac(A31, B11);
+            }
+
+          aie::store_v(pC1, C00.template to_vector<T_out>());
+          pC1 += MMUL::size_C;
+          aie::store_v(pC1, C01.template to_vector<T_out>());
+          pC1 += MMUL::size_C;
+          aie::store_v(pC2, C10.template to_vector<T_out>());
+          pC2 += MMUL::size_C;
+          aie::store_v(pC2, C11.template to_vector<T_out>());
+          pC2 += MMUL::size_C;
+          aie::store_v(pC3, C20.template to_vector<T_out>());
+          pC3 += MMUL::size_C;
+          aie::store_v(pC3, C21.template to_vector<T_out>());
+          pC3 += MMUL::size_C;
+          aie::store_v(pC4, C30.template to_vector<T_out>());
+          pC4 += MMUL::size_C;
+          aie::store_v(pC4, C31.template to_vector<T_out>());
+          pC4 += MMUL::size_C;
+        }
+    }
+
+  event1();
+}
+
+/* Similar to the kernel aboves, we expand matrix A (in 'm' dimension, or rowA)
+ * 4 times, while matrix B is expanded spatially 4 times (in 'n' dimension, or
+ * ColB), for even higher accumulator usage. This is very helpful in attaining
+ * high kernel efficiency for some precisions (e.g., bf16)
+ */
+template <typename T_in, typename T_out, unsigned rowA, unsigned colA,
+          unsigned colB, unsigned r, unsigned s, unsigned t>
+static inline void matmul_vectorized_4x4(const T_in *__restrict pA,
+                                         const T_in *__restrict pB,
+                                         T_out *__restrict pC) {
+
+  using MMUL = aie::mmul<r, s, t, T_in, T_in, accauto>;
+
+  event0();
+
+  for (unsigned z = 0; z < rowA; z += 4)
+    chess_prepare_for_pipelining chess_loop_range(2, ) {
+      T_out *__restrict pC1 = pC + (z * colB + 0) * MMUL::size_C;
+      T_out *__restrict pC2 = pC + ((z + 1) * colB + 0) * MMUL::size_C;
+      T_out *__restrict pC3 = pC + ((z + 2) * colB + 0) * MMUL::size_C;
+      T_out *__restrict pC4 = pC + ((z + 3) * colB + 0) * MMUL::size_C;
+
+      for (unsigned j = 0; j < colB; j += 4)
+#ifdef OPT_PERF_ENABLED
+        chess_flatten_loop
+#endif
+        {
+          const T_in *__restrict pA1 = pA + (z * colA + 0) * MMUL::size_A;
+          const T_in *__restrict pA2 = pA + ((z + 1) * colA + 0) * MMUL::size_A;
+          const T_in *__restrict pA3 = pA + ((z + 2) * colA + 0) * MMUL::size_A;
+          const T_in *__restrict pA4 = pA + ((z + 3) * colA + 0) * MMUL::size_A;
+
+          const T_in *__restrict pB1 = pB + (0 * colB + j) * MMUL::size_B;
+          const T_in *__restrict pB2 = pB + (0 * colB + (j + 1)) * MMUL::size_B;
+          const T_in *__restrict pB3 = pB + (0 * colB + (j + 2)) * MMUL::size_B;
+          const T_in *__restrict pB4 = pB + (0 * colB + (j + 3)) * MMUL::size_B;
+
+          aie::vector<T_in, MMUL::size_A> A0 = aie::load_v<MMUL::size_A>(pA1);
+          pA1 += MMUL::size_A;
+          aie::vector<T_in, MMUL::size_A> A1 = aie::load_v<MMUL::size_A>(pA2);
+          pA2 += MMUL::size_A;
+          aie::vector<T_in, MMUL::size_A> A2 = aie::load_v<MMUL::size_A>(pA3);
+          pA3 += MMUL::size_A;
+          aie::vector<T_in, MMUL::size_A> A3 = aie::load_v<MMUL::size_A>(pA4);
+          pA4 += MMUL::size_A;
+          aie::vector<T_in, MMUL::size_B> B0 = aie::load_v<MMUL::size_B>(pB1);
+          pB1 += MMUL::size_B * colB;
+          aie::vector<T_in, MMUL::size_B> B1 = aie::load_v<MMUL::size_B>(pB2);
+          pB2 += MMUL::size_B * colB;
+          aie::vector<T_in, MMUL::size_B> B2 = aie::load_v<MMUL::size_B>(pB3);
+          pB3 += MMUL::size_B * colB;
+          aie::vector<T_in, MMUL::size_B> B3 = aie::load_v<MMUL::size_B>(pB4);
+          pB4 += MMUL::size_B * colB;
+
+          aie::vector<T_out, MMUL::size_C> acc_C00 =
+              aie::load_v<MMUL::size_C>(pC1);
+          aie::vector<T_out, MMUL::size_C> acc_C01 =
+              aie::load_v<MMUL::size_C>(pC1 + MMUL::size_C);
+          aie::vector<T_out, MMUL::size_C> acc_C02 =
+              aie::load_v<MMUL::size_C>(pC1 + 2 * MMUL::size_C);
+          aie::vector<T_out, MMUL::size_C> acc_C03 =
+              aie::load_v<MMUL::size_C>(pC1 + 3 * MMUL::size_C);
+
+          aie::vector<T_out, MMUL::size_C> acc_C10 =
+              aie::load_v<MMUL::size_C>(pC2);
+          aie::vector<T_out, MMUL::size_C> acc_C11 =
+              aie::load_v<MMUL::size_C>(pC2 + MMUL::size_C);
+          aie::vector<T_out, MMUL::size_C> acc_C12 =
+              aie::load_v<MMUL::size_C>(pC2 + 2 * MMUL::size_C);
+          aie::vector<T_out, MMUL::size_C> acc_C13 =
+              aie::load_v<MMUL::size_C>(pC2 + 3 * MMUL::size_C);
+
+          aie::vector<T_out, MMUL::size_C> acc_C20 =
+              aie::load_v<MMUL::size_C>(pC3);
+          aie::vector<T_out, MMUL::size_C> acc_C21 =
+              aie::load_v<MMUL::size_C>(pC3 + MMUL::size_C);
+          aie::vector<T_out, MMUL::size_C> acc_C22 =
+              aie::load_v<MMUL::size_C>(pC3 + 2 * MMUL::size_C);
+          aie::vector<T_out, MMUL::size_C> acc_C23 =
+              aie::load_v<MMUL::size_C>(pC3 + 3 * MMUL::size_C);
+
+          aie::vector<T_out, MMUL::size_C> acc_C30 =
+              aie::load_v<MMUL::size_C>(pC4);
+          aie::vector<T_out, MMUL::size_C> acc_C31 =
+              aie::load_v<MMUL::size_C>(pC4 + MMUL::size_C);
+          aie::vector<T_out, MMUL::size_C> acc_C32 =
+              aie::load_v<MMUL::size_C>(pC4 + 2 * MMUL::size_C);
+          aie::vector<T_out, MMUL::size_C> acc_C33 =
+              aie::load_v<MMUL::size_C>(pC4 + 3 * MMUL::size_C);
+
+          MMUL C00(acc_C00);
+          MMUL C01(acc_C01);
+          MMUL C02(acc_C02);
+          MMUL C03(acc_C03);
+
+          MMUL C10(acc_C10);
+          MMUL C11(acc_C11);
+          MMUL C12(acc_C12);
+          MMUL C13(acc_C13);
+
+          MMUL C20(acc_C20);
+          MMUL C21(acc_C21);
+          MMUL C22(acc_C22);
+          MMUL C23(acc_C23);
+
+          MMUL C30(acc_C30);
+          MMUL C31(acc_C31);
+          MMUL C32(acc_C32);
+          MMUL C33(acc_C33);
+
+          C00.mac(A0, B0);
+          C01.mac(A0, B1);
+          C10.mac(A1, B0);
+          C11.mac(A1, B1);
+
+          C02.mac(A0, B2);
+          C03.mac(A0, B3);
+          C12.mac(A1, B2);
+          C13.mac(A1, B3);
+
+          C20.mac(A2, B0);
+          C21.mac(A2, B1);
+          C30.mac(A3, B0);
+          C31.mac(A3, B1);
+
+          C22.mac(A2, B2);
+          C23.mac(A2, B3);
+          C32.mac(A3, B2);
+          C33.mac(A3, B3);
+
+          for (unsigned i = 1; i < colA; ++i)
+#ifdef OPT_PERF_ENABLED
+            chess_flatten_loop
+#endif
+            {
+              A0 = aie::load_v<MMUL::size_A>(pA1);
+              pA1 += MMUL::size_A;
+              A1 = aie::load_v<MMUL::size_A>(pA2);
+              pA2 += MMUL::size_A;
+              A2 = aie::load_v<MMUL::size_A>(pA3);
+              pA3 += MMUL::size_A;
+              A3 = aie::load_v<MMUL::size_A>(pA4);
+              pA4 += MMUL::size_A;
+
+              B0 = aie::load_v<MMUL::size_B>(pB1);
+              pB1 += MMUL::size_B * colB;
+              B1 = aie::load_v<MMUL::size_B>(pB2);
+              pB2 += MMUL::size_B * colB;
+              B2 = aie::load_v<MMUL::size_B>(pB3);
+              pB3 += MMUL::size_B * colB;
+              B3 = aie::load_v<MMUL::size_B>(pB4);
+              pB4 += MMUL::size_B * colB;
+
+              C00.mac(A0, B0);
+              C01.mac(A0, B1);
+              C10.mac(A1, B0);
+              C11.mac(A1, B1);
+
+              C02.mac(A0, B2);
+              C03.mac(A0, B3);
+              C12.mac(A1, B2);
+              C13.mac(A1, B3);
+
+              C20.mac(A2, B0);
+              C21.mac(A2, B1);
+              C30.mac(A3, B0);
+              C31.mac(A3, B1);
+
+              C22.mac(A2, B2);
+              C23.mac(A2, B3);
+              C32.mac(A3, B2);
+              C33.mac(A3, B3);
+            }
+
+          aie::store_v(pC1, C00.template to_vector<T_out>());
+          pC1 += MMUL::size_C;
+          aie::store_v(pC1, C01.template to_vector<T_out>());
+          pC1 += MMUL::size_C;
+          aie::store_v(pC1, C02.template to_vector<T_out>());
+          pC1 += MMUL::size_C;
+          aie::store_v(pC1, C03.template to_vector<T_out>());
+          pC1 += MMUL::size_C;
+
+          aie::store_v(pC2, C10.template to_vector<T_out>());
+          pC2 += MMUL::size_C;
+          aie::store_v(pC2, C11.template to_vector<T_out>());
+          pC2 += MMUL::size_C;
+          aie::store_v(pC2, C12.template to_vector<T_out>());
+          pC2 += MMUL::size_C;
+          aie::store_v(pC2, C13.template to_vector<T_out>());
+          pC2 += MMUL::size_C;
+
+          aie::store_v(pC3, C20.template to_vector<T_out>());
+          pC3 += MMUL::size_C;
+          aie::store_v(pC3, C21.template to_vector<T_out>());
+          pC3 += MMUL::size_C;
+          aie::store_v(pC3, C22.template to_vector<T_out>());
+          pC3 += MMUL::size_C;
+          aie::store_v(pC3, C23.template to_vector<T_out>());
+          pC3 += MMUL::size_C;
+
+          aie::store_v(pC4, C30.template to_vector<T_out>());
+          pC4 += MMUL::size_C;
+          aie::store_v(pC4, C31.template to_vector<T_out>());
+          pC4 += MMUL::size_C;
+          aie::store_v(pC4, C32.template to_vector<T_out>());
+          pC4 += MMUL::size_C;
+          aie::store_v(pC4, C33.template to_vector<T_out>());
+          pC4 += MMUL::size_C;
+        }
+    }
+
+  event1();
+}
+
+// int16 MatMul kernel definion with int16 outputs.
+template <unsigned m, unsigned k, unsigned n>
+static inline void matmul_vectorized_4x4x4_i16_i16(const int16 *__restrict pA,
+                                                   const int16 *__restrict pB,
+                                                   int16 *__restrict pC) {
+
+  // After extensive experimentation, the 4x4x4 aie::mmul size was found to be
+  // optimal for AIE2, in combination with the 2x2 mmul expanded kernel
+  constexpr int r = 4;
+  constexpr int s = 4;
+  constexpr int t = 4;
+
+  // Since the kernel has been expanded twice for both A ('m' dimension) and B
+  // ('n' dimension), the following assertions veirify this even division for
+  // the single AIE MatMul dimensionality. Notice that 'k' dimension is not
+  // spatially expanded.
+  static_assert(m % (2 * r) == 0); // 'm' dimension
+  static_assert(k % s == 0);       // 'k' dimension
+  static_assert(n % (2 * t) == 0); // 'n' dimension
+
+  return matmul_vectorized_2x2_mmul<int16, int16, (m / r), (k / s), (n / t), r,
+                                    s, t>(pA, pB, pC);
+}
+
+// int16 MatMul kernel definion with int32 outputs.
+template <unsigned m, unsigned k, unsigned n>
+static inline void matmul_vectorized_4x4x4_i16_i32(const int16 *__restrict pA,
+                                                   const int16 *__restrict pB,
+                                                   int32 *__restrict pC) {
+
+  // After extensive experimentation, the 4x4x4 aie::mmul size was found to be
+  // optimal for AIE2, in combination with the 2x2 mmul expanded kernel
+  constexpr int r = 4;
+  constexpr int s = 4;
+  constexpr int t = 4;
+
+  // Since the kernel has been expanded twice for both A ('m' dimension) and B
+  // ('n' dimension), the following assertions veirify this even division for
+  // the single AIE MatMul dimensionality Notice that 'k' dimension is not
+  // spatially expanded.
+  static_assert(m % (2 * r) == 0); // 'm' dimension
+  static_assert(k % s == 0);       // 'k' dimension
+  static_assert(n % (2 * t) == 0); // 'n' dimension
+
+  return matmul_vectorized_2x2_mmul<int16, int32, (m / r), (k / s), (n / t), r,
+                                    s, t>(pA, pB, pC);
+}
+
+// bf16 MatMul kernel definion with bf16 outputs.
+template <unsigned m, unsigned k, unsigned n>
+static inline void
+matmul_vectorized_4x8x4_bf16_bf16(const bfloat16 *__restrict pA,
+                                  const bfloat16 *__restrict pB,
+                                  bfloat16 *__restrict pC) {
+
+  // After extensive experimentation, the 4x8x4 aie::mmul size was found to be
+  // optimal for AIE2, in combination with the 4x4 mmul expanded kernel
+  constexpr int r = 4;
+  constexpr int s = 8;
+  constexpr int t = 4;
+
+  // Since the kernel has been expanded 4 times for both A ('m' dimension) and B
+  // ('n' dimension), the following assertions veirify this even division for
+  // the single AIE MatMul dimensionality Notice that 'k' dimension is not
+  // spatially expanded.
+  static_assert(m % (4 * r) == 0); // 'm' dimension
+  static_assert(k % s == 0);       // 'k' dimension
+  static_assert(n % (4 * t) == 0); // 'n' dimension
+
+  return matmul_vectorized_4x4<bfloat16, bfloat16, (m / r), (k / s), (n / t), r,
+                               s, t>(pA, pB, pC);
+}
+
+// bf16 MatMul kernel definion with fp32 outputs.
+template <unsigned m, unsigned k, unsigned n>
+static inline void
+matmul_vectorized_4x8x4_bf16_f32(const bfloat16 *__restrict pA,
+                                 const bfloat16 *__restrict pB,
+                                 float *__restrict pC) {
+
+  // After extensive experimentation, the 4x8x4 aie::mmul size was found to be
+  // optimal for AIE2, in combination with the 4x4 mmul expanded kernel
+  constexpr int r = 4;
+  constexpr int s = 8;
+  constexpr int t = 4;
+
+  // Since the kernel has been expanded 4 times for both A ('m' dimension) and B
+  // ('n' dimension), the following assertions veirify this even division for
+  // the single AIE MatMul dimensionality Notice that 'k' dimension is not
+  // spatially expanded.
+  static_assert(m % (4 * r) == 0); // 'm' dimension
+  static_assert(k % s == 0);       // 'k' dimension
+  static_assert(n % (4 * t) == 0); // 'n' dimension
+
+  return matmul_vectorized_4x4<bfloat16, float, (m / r), (k / s), (n / t), r, s,
+                               t>(pA, pB, pC);
+}
+
+// int8 MatMul kernel definion with int8 outputs.
+template <unsigned m, unsigned k, unsigned n>
+static inline void matmul_vectorized_4x8x8_i8_i8(const int8 *__restrict pA,
+                                                 const int8 *__restrict pB,
+                                                 int8 *__restrict pC) {
+
+  // After extensive experimentation, the 4x8x8 aie::mmul size was found to be
+  // optimal for AIE2, in combination with the 4x2 mmul expanded kernel
+  constexpr int r = 4;
+  constexpr int s = 8;
+  constexpr int t = 8;
+
+  // Since the kernel has been expanded 4 times for A ('m' dimension) and 2
+  // times for B ('n' dimension), the following assertions veirify this even
+  // division for the single AIE MatMul dimensionality Notice that 'k' dimension
+  // is not spatially expanded.
+  static_assert(m % (4 * r) == 0); // 'm' dimension
+  static_assert(k % s == 0);       // 'k' dimension
+  static_assert(n % (2 * t) == 0); // 'n' dimension
+
+  return matmul_vectorized_4x2_mmul<int8, int8, (m / r), (k / s), (n / t), r, s,
+                                    t>(pA, pB, pC);
+}
+
+// int8 MatMul kernel definion with int16 outputs.
+template <unsigned m, unsigned k, unsigned n>
+static inline void matmul_vectorized_4x8x8_i8_i16(const int8 *__restrict pA,
+                                                  const int8 *__restrict pB,
+                                                  int16 *__restrict pC) {
+
+  // After extensive experimentation, the 4x8x8 aie::mmul size was found to be
+  // optimal for AIE2, in combination with the 4x2 mmul expanded kernel
+  constexpr int r = 4;
+  constexpr int s = 8;
+  constexpr int t = 8;
+
+  // Since the kernel has been expanded 4 times for A ('m' dimension) and 2
+  // times for B ('n' dimension), the following assertions veirify this even
+  // division for the single AIE MatMul dimensionality Notice that 'k' dimension
+  // is not spatially expanded.
+  static_assert(m % (4 * r) == 0); // 'm' dimension
+  static_assert(k % s == 0);       // 'k' dimension
+  static_assert(n % (2 * t) == 0); // 'n' dimension
+
+  return matmul_vectorized_4x2_mmul<int8, int16, (m / r), (k / s), (n / t), r,
+                                    s, t>(pA, pB, pC);
+}
+
+// int8 MatMul kernel definion with int32 outputs.
+template <unsigned m, unsigned k, unsigned n>
+static inline void matmul_vectorized_4x8x8_i8_i32(const int8 *__restrict pA,
+                                                  const int8 *__restrict pB,
+                                                  int32 *__restrict pC) {
+
+  // Since the kernel has been expanded 4 times for A ('m' dimension) and 2
+  // times for B ('n' dimension), in combination with the 4x2 mmul expanded
+  // kernel
+  constexpr int r = 4;
+  constexpr int s = 8;
+  constexpr int t = 8;
+
+  // Since the kernel has been expanded twice for both A ('m' dimension) and B
+  // ('n' dimension), the following assertions veirify this even division for
+  // the single AIE MatMul dimensionality Notice that 'k' dimension is not
+  // spatially expanded.
+  static_assert(m % (4 * r) == 0); // 'm' dimension
+  static_assert(k % s == 0);       // 'k' dimension
+  static_assert(n % (2 * t) == 0); // 'n' dimension
+
+  return matmul_vectorized_4x2_mmul<int8, int32, (m / r), (k / s), (n / t), r,
+                                    s, t>(pA, pB, pC);
+}
+
+extern "C" {
+
+// If you want to compile microkernels with different inner tile sizes,
+// define DIM_M, DIM_K and DIM_N at compile time using -DDIM_M 32 etc.
+// These dimensions must be divisible by the r, s, t dimensions used in
+// the kernels.
+
+#ifndef DIM_M
+#define DIM_M 64
+#endif
+
+#ifndef DIM_K
+#define DIM_K 64
+#endif
+
+#ifndef DIM_N
+#define DIM_N 64
+#endif
+
+#ifdef i8_i8_ONLY
+#define combos(X) X(int8, i8, int8, i8, 4, 8, 8)
+#endif
+
+#ifdef i8_i16_ONLY
+#define combos(X) X(int8, i8, int16, i16, 4, 8, 8)
+#endif
+
+#ifdef i8_i32_ONLY
+#define combos(X) X(int8, i8, int32, i32, 4, 8, 8)
+#endif
+
+#ifdef i16_i16_ONLY
+#define combos(X) X(int16, i16, int16, i16, 4, 4, 4)
+#endif
+
+#ifdef i16_i32_ONLY
+#define combos(X) X(int16, i16, int32, i32, 4, 4, 4)
+#endif
+
+#ifdef bf16_bf16_ONLY
+#define combos(X) X(bfloat16, bf16, bfloat16, bf16, 4, 8, 4)
+#endif
+
+#ifdef bf16_f32_ONLY
+#define combos(X) X(bfloat16, bf16, float, f32, 4, 8, 4)
+#endif
+
+#ifndef combos
+#define combos(X)                                                              \
+  X(int8, i8, int8, i8, 4, 8, 8)                                               \
+  X(int16, i16, int16, i16, 4, 4, 4)                                           \
+  X(int16, i16, int32, i32, 4, 4, 4)                                           \
+  X(bfloat16, bf16, bfloat16, bf16, 4, 8, 4)                                   \
+  X(bfloat16, bf16, float, f32, 4, 8, 4)
+#endif
+
+#define matmul_vectorized_c_func(ctype_in, mlir_type_in, ctype_out,            \
+                                 mlir_type_out, r, s, t)                       \
+  void matmul_##mlir_type_in##_##mlir_type_out(ctype_in *a_in, ctype_in *b_in, \
+                                               ctype_out *c_out) {             \
+    matmul_vectorized_##r##x##s##x##t##_##mlir_type_in##_##mlir_type_out<      \
+        DIM_M, DIM_K, DIM_N>(a_in, b_in, c_out);                               \
+  }
+
+#define matmul_scalar_c_func(ctype_in, mlir_type_in, ctype_out, mlir_type_out, \
+                             r, s, t)                                          \
+  void matmul_scalar_##mlir_type_in##_##mlir_type_out(                         \
+      ctype_in *a_in, ctype_in *b_in, ctype_out *c_out) {                      \
+    matmul_scalar<ctype_in, ctype_out, DIM_M, DIM_K, DIM_N>(a_in, b_in,        \
+                                                            c_out);            \
+  }
+
+#define zero_vectorized_c_func(ctype_in, mlir_type_in, ctype_out,              \
+                               mlir_type_out, r, s, t)                         \
+  void zero_##mlir_type_out(ctype_out *c_out) {                                \
+    zero_vectorized<ctype_out, DIM_M, DIM_N>(c_out);                           \
+  }
+
+#define zero_scalar_c_func(ctype_in, mlir_type_in, ctype_out, mlir_type_out,   \
+                           r, s, t)                                            \
+  void zero_scalar_##mlir_type_out(ctype_out *c_out) {                         \
+    zero_scalar<ctype_out, DIM_M, DIM_N>(c_out);                               \
+  }
+
+combos(matmul_vectorized_c_func) combos(matmul_scalar_c_func)
+    combos(zero_vectorized_c_func) combos(zero_scalar_c_func)
+
+} // extern "C"

--- a/src/ggml-hsa/kernels/mul_mat.py
+++ b/src/ggml-hsa/kernels/mul_mat.py
@@ -3,16 +3,18 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2023 AMD Inc.
 import argparse
 from ml_dtypes import bfloat16
 import numpy as np
+import sys
 
-from aie.iron import Kernel, ObjectFifo, Program, Runtime, Worker
-from aie.iron.placers import SequentialPlacer
-from aie.iron.device import NPU1Col1, NPU1Col2, NPU1Col4, Tile
-from aie.iron.controlflow import range_
-from aie.helpers.taplib import TensorAccessSequence, TensorTiler2D
+from aie.extras.context import mlir_mod_ctx
+
+from aie.dialects.aie import *
+from aie.dialects.aiex import *
+from aie.helpers.dialects.ext.scf import _for as range_
+from aie.helpers.taplib import TensorAccessPattern, TensorAccessSequence
 
 dtype_map = {
     "bf16": bfloat16,
@@ -53,24 +55,26 @@ def main():
         "of the input/output matrices. These objects can be used for visualization.",
     )
     args = argparser.parse_args()
-    maybe_module = my_matmul(
-        args.M,
-        args.K,
-        args.N,
-        args.m,
-        args.k,
-        args.n,
-        args.n_aie_cols,
-        args.dtype_in,
-        args.dtype_out,
-        args.b_col_maj,
-        args.trace_size,
-        args.generate_taps,
-    )
+    with mlir_mod_ctx() as ctx:
+        maybe_taps = my_matmul(
+            args.M,
+            args.K,
+            args.N,
+            args.m,
+            args.k,
+            args.n,
+            args.n_aie_cols,
+            args.dtype_in,
+            args.dtype_out,
+            args.b_col_maj,
+            args.trace_size,
+            args.generate_taps,
+        )
+        # print(ctx.module.operation.verify())
+        print(ctx.module)
+
     if args.generate_taps:
-        return maybe_module
-    else:
-        print(maybe_module)
+        return maybe_taps
 
 
 def ceildiv(a, b):
@@ -159,11 +163,11 @@ def my_matmul(
 
     dev = None
     if n_aie_cols == 1:
-        dev = NPU1Col1()
+        dev = AIEDevice.npu1_1col
     elif n_aie_cols == 2:
-        dev = NPU1Col2()
+        dev = AIEDevice.npu1_2col
     elif n_aie_cols == 4:
-        dev = NPU1Col4()
+        dev = AIEDevice.npu1_4col
 
     # These will hold TensorAccessPattern objects that represent the runtime
     # npu_dma_memcpy_nd operations of this design. They are only used if generate_taps is true
@@ -171,338 +175,366 @@ def my_matmul(
     B_taps = []
     C_taps = []
 
-    # Define tensor types
-    A_ty = np.ndarray[(M * K,), np.dtype[dtype_in]]
-    B_ty = np.ndarray[(K * N,), np.dtype[dtype_in]]
-    C_ty = np.ndarray[(M * N,), np.dtype[dtype_out]]
-    A_l2_ty = np.ndarray[(m * k * n_A_tiles_per_shim,), np.dtype[dtype_in]]
-    B_l2_ty = np.ndarray[(k * n,), np.dtype[dtype_in]]
-    C_l2_ty = np.ndarray[(m * n * n_aie_rows,), np.dtype[dtype_out]]
-    A_l1_ty = np.ndarray[(m, k), np.dtype[dtype_in]]
-    B_l1_ty = np.ndarray[(k, n), np.dtype[dtype_in]]
-    C_l1_ty = np.ndarray[(m, n), np.dtype[dtype_out]]
+    @device(dev)
+    def device_body():
+        A_l2_ty = np.ndarray[(m * k * n_A_tiles_per_shim,), np.dtype[dtype_in]]
+        B_l2_ty = np.ndarray[(k * n,), np.dtype[dtype_in]]
+        C_l2_ty = np.ndarray[(m * n * n_aie_rows,), np.dtype[dtype_out]]
+        A_l1_ty = np.ndarray[(m, k), np.dtype[dtype_in]]
+        B_l1_ty = np.ndarray[(k, n), np.dtype[dtype_in]]
+        C_l1_ty = np.ndarray[(m, n), np.dtype[dtype_out]]
 
-    # AIE Core Function declarations
-    zero_kernel = Kernel(f"zero_{dtype_out_str}", f"mm_{m}x{k}x{n}.o", [C_l1_ty])
-    matmul_vectorized_func_name = (
-        f"matmul_{dtype_in_str}_{dtype_out_str}"
-        if not b_col_maj
-        else f"matmul_{dtype_in_str}_{dtype_out_str}_b_col_maj"
-    )
-    matmul_kernel = Kernel(
-        matmul_vectorized_func_name,
-        f"mm_{m}x{k}x{n}.o",
-        [A_l1_ty, B_l1_ty, C_l1_ty],
-    )
-
-    # Tile declarations as tile[row][col]
-    tiles = [[(col, row) for col in range(0, n_aie_cols)] for row in range(0, 6)]
-    core_tiles = tiles[2:]
-
-    # AIE-array data movement with object fifos
-    A_l3l2_fifos = [None] * n_aie_cols
-    A_l2l1_fifos = [None] * n_aie_rows
-
-    B_l3l2_fifos = [None] * n_aie_cols
-    B_l2l1_fifos = [None] * n_aie_cols
-
-    C_l1l2_fifos = [[None] * n_aie_cols for _ in range(n_aie_rows)]
-    C_l2l3_fifos = [None] * n_aie_cols
-
-    # Input A
-    for col in range(n_aie_cols):
-        A_l3l2_fifos[col] = ObjectFifo(
-            A_l2_ty, name=f"A_L3L2_{col}", default_depth=fifo_depth
+        # AIE Core Function declarations
+        zero = external_func(f"zero_{dtype_out_str}", inputs=[C_l1_ty])
+        matmul_vectorized_func_name = (
+            f"matmul_{dtype_in_str}_{dtype_out_str}"
+            if not b_col_maj
+            else f"matmul_{dtype_in_str}_{dtype_out_str}_b_col_maj"
         )
-        # If n_cols == n_rows, n_A_tiles_per_shim is 1 and
-        # this simply links a_l3l2_fifos[col] to a_l2l1_fifos[row] directly,
-        # where col == row.
-        # If n_cols < n_rows, each column receives multiple rows of
-        # tiles; distribute it along rows of AIE cores.
-        start_row = col * n_A_tiles_per_shim
-        stop_row = start_row + n_A_tiles_per_shim
-        of_offsets = [m * k * i for i in range(stop_row - start_row)]
-        dims_to_stream = [
-            [
-                (m // r, r * k),
-                (k // s, s),
-                (r, k),
-                (s, 1),
-            ]
-        ] * (stop_row - start_row)
-        a_tmp_fifos = (
-            A_l3l2_fifos[col]
-            .cons()
-            .split(
-                of_offsets,
-                obj_types=[A_l1_ty] * (stop_row - start_row),
-                names=[f"A_L2L1_{row}" for row in range(start_row, stop_row)],
-                dims_to_stream=dims_to_stream,
-                placement=Tile(col, 1),
+        matmul = external_func(
+            matmul_vectorized_func_name,
+            inputs=[A_l1_ty, B_l1_ty, C_l1_ty],
+        )
+
+        # Tile declarations as tile[row][col]
+        tiles = [
+            [tile(col, row) for col in range(0, n_aie_cols)] for row in range(0, 6)
+        ]
+        shim_tiles = tiles[0]
+        mem_tiles = tiles[1]
+        core_tiles = tiles[2:]
+
+        # AIE-array data movement with object fifos
+        A_l3l2_fifos = [None] * n_aie_cols
+        A_l2l1_fifos = [None] * n_aie_rows
+
+        B_l3l2_fifos = [None] * n_aie_cols
+        B_l2l1_fifos = [None] * n_aie_cols
+
+        C_l1l2_fifos = [[None] * n_aie_cols for _ in range(n_aie_rows)]
+        C_l2l3_fifos = [None] * n_aie_cols
+
+        # Input A
+        for row in range(n_aie_rows):
+            A_l2l1_fifos[row] = object_fifo(
+                f"A_L2L1_{row}",
+                mem_tiles[row // n_A_tiles_per_shim],
+                core_tiles[row][0:n_aie_cols],  # broadcast along one row
+                fifo_depth,
+                A_l1_ty,
+                [
+                    (m // r, r * k),
+                    (k // s, s),
+                    (r, k),
+                    (s, 1),
+                ],
             )
-        )
-
-        for i in range(stop_row - start_row):
-            A_l2l1_fifos[i + start_row] = a_tmp_fifos[i]
+        for col in range(n_aie_cols):
+            A_l3l2_fifos[col] = object_fifo(
+                f"A_L3L2_{col}",
+                shim_tiles[col],
+                mem_tiles[col],
+                fifo_depth,
+                A_l2_ty,
+            )
+            # If n_cols == n_rows, n_A_tiles_per_shim is 1 and
+            # this simply links a_l3l2_fifos[col] to a_l2l1_fifos[row] directly,
+            # where col == row.
+            # If n_cols < n_rows, each column receives multiple rows of
+            # tiles; distribute it along rows of AIE cores.
+            start_row = col * n_A_tiles_per_shim
+            stop_row = start_row + n_A_tiles_per_shim
+            if stop_row - start_row > 1:
+                of_offsets = [m * k * i for i in range(stop_row - start_row)]
+            else:
+                of_offsets = []
+            object_fifo_link(
+                A_l3l2_fifos[col],
+                [A_l2l1_fifos[row] for row in range(start_row, stop_row)],
+                [],
+                of_offsets,
+            )
 
         # Input B
-        B_l3l2_fifos[col] = ObjectFifo(
-            B_l2_ty, name=f"B_L3L2_{col}", default_depth=fifo_depth
-        )
-        if b_col_maj:
-            dims_to_stream = [(n // t, t * k), (k // s, s), (t, k), (s, 1)]
-        else:
-            dims_to_stream = [(k // s, s * n), (n // t, t), (s, n), (t, 1)]
-        B_l2l1_fifos[col] = (
-            B_l3l2_fifos[col]
-            .cons()
-            .forward(
-                obj_type=B_l1_ty,
-                name=f"B_L2L1_{col}",
-                dims_to_stream=dims_to_stream,
-                placement=Tile(col, 1),
+        for col in range(n_aie_cols):
+            B_l3l2_fifos[col] = object_fifo(
+                f"B_L3L2_{col}",
+                shim_tiles[col],
+                mem_tiles[col],
+                fifo_depth,
+                B_l2_ty,
             )
-        )
+            B_l2l1_fifos[col] = object_fifo(
+                f"B_L2L1_{col}",
+                mem_tiles[col],
+                [
+                    core_tiles[j][col] for j in range(n_aie_rows)
+                ],  # broadcast along one column
+                fifo_depth,
+                B_l1_ty,
+                (
+                    [
+                        (k // s, s * n),
+                        (n // t, t),
+                        (s, n),
+                        (t, 1),
+                    ]
+                    if not b_col_maj
+                    else [
+                        (n // t, t * k),
+                        (k // s, s),
+                        (t, k),
+                        (s, 1),
+                    ]
+                ),
+            )
+            object_fifo_link(B_l3l2_fifos[col], B_l2l1_fifos[col])
 
         # Output C
-        C_l2l3_fifos[col] = ObjectFifo(
-            C_l2_ty,
-            name=f"C_L2L3_{col}",
-            default_depth=fifo_depth,
-            dims_to_stream=[(m // r, r * n), (r, t), (n // t, r * t), (t, 1)],
-        )
-        of_offsets = [m * n * i for i in range(n_aie_rows)]
-
-        # join along one column
-        c_tmp_fifos = (
-            C_l2l3_fifos[col]
-            .prod()
-            .join(
-                of_offsets,
-                obj_types=[C_l1_ty] * n_aie_rows,
-                names=[f"C_L1L2_{col}_{row}" for row in range(n_aie_rows)],
-                depths=[fifo_depth] * n_aie_rows,
-                placement=Tile(col, 1),
-            )
-        )
-        for j in range(n_aie_rows):
-            C_l1l2_fifos[j][col] = c_tmp_fifos[j]
-
-    # Tasks for each worker to perform
-    def core_fn(in_a, in_b, out_c, zero, matmul):
-        loop = range(1)  # Workaround for issue #1547
-        if n_tiles_per_core > 1:
-            loop = range_(n_tiles_per_core)
-        for _ in loop:
-            elem_out = out_c.acquire(1)
-            zero(elem_out)
-
-            for _ in range_(K // k):
-                elem_in_a = in_a.acquire(1)
-                elem_in_b = in_b.acquire(1)
-                matmul(elem_in_a, elem_in_b, elem_out)
-                in_a.release(1)
-                in_b.release(1)
-            out_c.release(1)
-
-    # Set up compute tiles
-    workers = []
-    for row in range(n_aie_rows):
         for col in range(n_aie_cols):
-            tile_col, tile_row = core_tiles[row][col]
-            workers.append(
-                Worker(
-                    core_fn,
-                    [
-                        A_l2l1_fifos[row].cons(),
-                        B_l2l1_fifos[col].cons(),
-                        C_l1l2_fifos[row][col].prod(),
-                        zero_kernel,
-                        matmul_kernel,
-                    ],
-                    placement=Tile(tile_col, tile_row),
+            for row in range(n_aie_rows):
+                C_l1l2_fifos[row][col] = object_fifo(
+                    f"C_L1L2_{col}_{row}",
+                    core_tiles[row][col],
+                    mem_tiles[col],
+                    fifo_depth,
+                    C_l1_ty,
                 )
+            C_l2l3_fifos[col] = object_fifo(
+                f"C_L2L3_{col}",
+                mem_tiles[col],
+                shim_tiles[col],
+                fifo_depth,
+                C_l2_ty,
+                [
+                    (m // r, r * n),
+                    (r, t),
+                    (n // t, r * t),
+                    (t, 1),
+                ],
             )
+            if n_aie_rows > 1:
+                of_offsets = [m * n * i for i in range(n_aie_rows)]
+            else:
+                of_offsets = []
+            object_fifo_link(
+                [C_l1l2_fifos[j][col] for j in range(n_aie_rows)],
+                C_l2l3_fifos[col],
+                of_offsets,
+                [],
+            )  # join along one column
 
-    # We are limited in the number of BDs. After synchronizing, we can reuse BDs.
-    # We only transfer 6 rows of tiles at once before starting a new transfer block.
-    # tb = transfer block; block of transfers before sync call
-    tb_max_n_rows = 4
-    tb_n_rows = tb_max_n_rows // 2
+        # Set up compute tiles
+        for row in range(n_aie_rows):
+            for col in range(n_aie_cols):
 
-    # Define tensor access patterns (tiling) for A, B, and C
-    A_tiles = TensorTiler2D.group_tiler(
-        (M, K),  # Size of A matrix
-        (m * n_A_tiles_per_shim, k),  # Size of A (smallest) tile
-        (1, K // k),  # Size of "group" of tiles
-        # Repeat data so can distribute across whole column
-        pattern_repeat=N // n // n_aie_cols,
-    )
-    if b_col_maj:
-        B_tiles = TensorTiler2D.step_tiler(
-            (K, N),  # Size of B matrix
-            (k, n),  # Size of B tile
-            # Number of tiles per transfer in each dimension (whole col, partial row)
-            tile_group_repeats=(K // k // n_aie_cols, N // n),
-            # Contiguous tile group in col, but send every n_aie_cols-th tile in the row
-            tile_group_steps=(n_aie_cols, 1),
+                @core(core_tiles[row][col], f"mm_{m}x{k}x{n}.o")
+                def core_body():
+                    for _ in range_(0xFFFFFFFF):
+                        loop = (
+                            range_(n_tiles_per_core)
+                            if n_tiles_per_core > 1
+                            else range(1)
+                        )  # Workaround for issue #1547
+                        for _ in loop:
+                            elem_out = C_l1l2_fifos[row][col].acquire(
+                                ObjectFifoPort.Produce, 1
+                            )
+                            zero(elem_out)
+
+                            for _ in range_(K // k):
+                                elem_in_a = A_l2l1_fifos[row].acquire(
+                                    ObjectFifoPort.Consume, 1
+                                )
+                                elem_in_b = B_l2l1_fifos[col].acquire(
+                                    ObjectFifoPort.Consume, 1
+                                )
+                                matmul(elem_in_a, elem_in_b, elem_out)
+                                A_l2l1_fifos[row].release(ObjectFifoPort.Consume, 1)
+                                B_l2l1_fifos[col].release(ObjectFifoPort.Consume, 1)
+
+                            C_l1l2_fifos[row][col].release(ObjectFifoPort.Produce, 1)
+
+        # To/from AIE-array data movement
+        @runtime_sequence(
+            np.ndarray[(M * K,), np.dtype[dtype_in]],
+            np.ndarray[(K * N,), np.dtype[dtype_in]],
+            np.ndarray[(M * N,), np.dtype[dtype_out]],
         )
-    else:
-        B_tiles = TensorTiler2D.step_tiler(
-            (K, N),  # Size of B matrix
-            (k, n),  # Size of B tile
-            # Number of tiles per transfer in each dimension (whole col, partial row)
-            tile_group_repeats=(K // k, N // n // n_aie_cols),
-            # Contiguous tile group in col, but send every n_aie_cols-th tile in the row
-            tile_group_steps=(1, n_aie_cols),
-            tile_group_col_major=True,  # Send all tiles in column before moving on to next column
-        )
-    C_tiles = TensorTiler2D.step_tiler(
-        (M, N),  # Size of C matrix
-        (m * n_aie_rows, n),  # Size of C tile
-        # Number of tiles per transfer in each dimension (partial col, partial row)
-        tile_group_repeats=(tb_n_rows, N // n // n_aie_cols),
-        # Collect every n_aie_cols row at a time (mirroring how we sent in B data)
-        tile_group_steps=(1, n_aie_cols),
-    )
-    c_index = 0
-
-    # Runtime operations to move data to/from the AIE-array
-    rt = Runtime()
-    with rt.sequence(A_ty, B_ty, C_ty) as (A, B, C):
-        rt.start(*workers)
-
-        # Task groups will be used to determine when to sync/await/free DMA runtime ops
-        tg = rt.task_group()
-        for tb in range(ceildiv(M // m // n_aie_rows, tb_max_n_rows)):
-            for pingpong in [0, 1]:
-                if c_index >= len(C_tiles):
-                    # May not have pong iteration in some cases
-                    break
-
-                row_base = tb * tb_max_n_rows + pingpong * tb_max_n_rows // 2
-                current_tb_n_rows = min(
-                    [tb_max_n_rows // 2, M // m // n_aie_rows - row_base]
-                )
-
-                for col in range(n_aie_cols):
-
-                    # This line does not change MLIR output at all - it's just for recording data movement
-                    C_taps.append(C_tiles[c_index])
-
-                    # C Output Transfer:
-                    # The smallest transfer unit is a (m*n_aie_rows)-x-(n)-sized sub-tile of the matrix.
-                    # Transfer one such tile for every (n_aie_cols)-th column, evenly spaced,
-                    # then repeat that (tb_n_rows) times for the next contiguous blocks of rows.
-                    # Each shim will start at a different column offset, transferring interleaved
-                    # columns. For example, shim 0 may transfer the blocks marked 0 below, and shim 1
-                    # may transfer the blocks marked 1.
-                    #
-                    #             N
-                    #      ----------------
-                    #     |0011    0011    |
-                    #     |0011    0011    |
-                    #     |0011    0011    |
-                    # M   |0011    0011    |
-                    #     |                |
-                    #     |                |
-                    #     |                |
-                    #     |                |
-                    #      ----------------
-                    rt.drain(
-                        C_l2l3_fifos[col].cons(),
-                        C,
-                        tap=C_tiles[c_index],
-                        wait=True,
-                        task_group=tg,
-                        placement=Tile(col, 0),
+        def sequence(A, B, C):
+            # We are limited in the number of BDs. After synchronizing, we can reuse BDs.
+            # We only transfer 6 rows of tiles at once before starting a new transfer block.
+            tb_max_n_rows = (
+                4  # tb = transfer block; block of transfers before sync call
+            )
+            for tb in range(ceildiv(M // m // n_aie_rows, tb_max_n_rows)):
+                for pingpong in [0, 1]:
+                    M // m // n_aie_rows // tb_max_n_rows
+                    row_base = tb * tb_max_n_rows + pingpong * tb_max_n_rows // 2
+                    bd_id_base = 8 * pingpong
+                    tb_n_rows = min(
+                        [tb_max_n_rows // 2, M // m // n_aie_rows - row_base]
                     )
-                    c_index += 1
+                    if tb_n_rows <= 0:
+                        # for small input sizes, we may not even need a "pong" iteration
+                        break
+                    for col in range(n_aie_cols):
 
-                    for tile_row in range(current_tb_n_rows):
-
-                        # A input transfer:
-                        #
-                        # The smallest transfer unit is a (m*n_A_tiles_per_shim)-sized sub-tile of the input matrix.
-                        # Transfer one such tile for every column, contiguously.
-                        # Repeat this transfer with identical tiles a total of (N//n//n_aie_cols) times.
-                        # Each shim transfers the tiles for separate rows. For example, shim 0 may transfer the
-                        # tiles marked 0 below, and shim 1 may transfer the tiles marked 1.
-                        #             K
-                        #      ----------------
-                        #     |0000000000000000|    (repeated N//n//n_aie_cols times)
-                        #     |0000000000000000|
-                        #     |1111111111111111|
-                        # M   |1111111111111111|
-                        #     |                |
-                        #     |                |
-                        #     |                |
-                        #     |                |
-                        #      ----------------
-                        tile_offset = ((row_base + tile_row) * n_aie_cols + col) % len(
-                            A_tiles
-                        )
-
-                        rt.fill(
-                            A_l3l2_fifos[col].prod(),
-                            A,
-                            tap=A_tiles[tile_offset],
-                            task_group=tg,
-                            placement=Tile(col, 0),
-                        )
-                        # Use the calculated sizes/strides/offsets to record the data movement
-                        # caused by the above call to npu_dma_memcpy_nd.
-                        # This line does not change MLIR output at all.
-
-                        # B input transfer:
-                        # Transfer the first a (n)-wide block of columns of B,
-                        # Then transfer the (n_aie_columns)-th such block, and so on.
-                        # Each shim will start at a different column offset.
-                        # For example, shim 0 may transfer the tiles marked 0 below,
-                        # and shim 1 may transfer the tiles marked 1.
+                        # C Output Transfer:
+                        # The smallest transfer unit is a (m*n_aie_rows)-x-(n)-sized sub-tile of the matrix.
+                        # Transfer one such tile for every (n_aie_cols)-th column, evenly spaced,
+                        # then repeat that (tb_n_rows) times for the next contiguous blocks of rows.
+                        # Each shim will start at a different column offset, transferring interleaved
+                        # columns. For example, shim 0 may transfer the blocks marked 0 below, and shim 1
+                        # may transfer the blocks marked 1.
                         #
                         #             N
                         #      ----------------
                         #     |0011    0011    |
                         #     |0011    0011    |
                         #     |0011    0011    |
-                        # K   |0011    0011    |
-                        #     |0011    0011    |
-                        #     |0011    0011    |
-                        #     |0011    0011    |
-                        #     |0011    0011    |
+                        # M   |0011    0011    |
+                        #     |                |
+                        #     |                |
+                        #     |                |
+                        #     |                |
                         #      ----------------
-                        rt.fill(
-                            B_l3l2_fifos[col].prod(),
-                            B,
-                            tap=B_tiles[col],
-                            task_group=tg,
-                            placement=Tile(col, 0),
+                        C_row_offset = row_base * m * n_aie_rows * N
+                        C_col_offset = col * n
+                        C_offset = C_col_offset + C_row_offset
+                        C_sizes = [tb_n_rows, N // n // n_aie_cols, m * n_aie_rows, n]
+                        C_strides = [m * n_aie_rows * N, n * n_aie_cols, N, 1]
+                        npu_dma_memcpy_nd(
+                            metadata=C_l2l3_fifos[col],
+                            bd_id=bd_id_base,
+                            mem=C,
+                            offsets=[0, 0, 0, C_offset],
+                            sizes=C_sizes,
+                            strides=C_strides,
+                        )
+                        # Use the calculated sizes/strides/offsets to record the data movement
+                        # caused by the above call to npu_dma_memcpy_nd.
+                        # This line does not change MLIR output at all.
+                        C_taps.append(
+                            TensorAccessPattern(
+                                (M, N),
+                                offset=C_offset,
+                                sizes=C_sizes,
+                                strides=C_strides,
+                            )
                         )
 
-                        # These lines do not change MLIR output at all - they are just for recording data movement
-                        A_taps.append(A_tiles[tile_offset])
-                        B_taps.append(B_tiles[col])
-                if tb > 0 or (tb == 0 and pingpong > 0):
-                    rt.finish_task_group(tg)
-                    tg = rt.task_group()
-        rt.finish_task_group(tg)
+                        for tile_row in range(tb_n_rows):
+
+                            # A input transfer:
+                            #
+                            # The smallest transfer unit is a (m*n_A_tiles_per_shim)-sized sub-tile of the input matrix.
+                            # Transfer one such tile for every column, contiguously.
+                            # Repeat this transfer with identical tiles a total of (N//n//n_aie_cols) times.
+                            # Each shim transfers the tiles for separate rows. For example, shim 0 may transfer the
+                            # tiles marked 0 below, and shim 1 may transfer the tiles marked 1.
+                            #             K
+                            #      ----------------
+                            #     |0000000000000000|    (repeated N//n//n_aie_cols times)
+                            #     |0000000000000000|
+                            #     |1111111111111111|
+                            # M   |1111111111111111|
+                            #     |                |
+                            #     |                |
+                            #     |                |
+                            #     |                |
+                            #      ----------------
+                            A_block_offset = (
+                                (row_base + tile_row) * n_aie_rows * m * K
+                            )  # base address for this transfer block for all BDs
+                            A_row_offset = (
+                                col * n_A_tiles_per_shim * m * K
+                            )  # base address for the shim in this column
+                            A_offset = A_block_offset + A_row_offset
+                            A_sizes = [
+                                N // n // n_aie_cols,
+                                K // k,
+                                m * n_A_tiles_per_shim,
+                                k,
+                            ]
+                            A_strides = [0, k, K, 1]
+                            npu_dma_memcpy_nd(
+                                metadata=A_l3l2_fifos[col],
+                                bd_id=bd_id_base + 2 * tile_row + 1,
+                                mem=A,
+                                offsets=[0, 0, 0, A_offset],
+                                sizes=A_sizes,
+                                strides=A_strides,
+                            )
+                            # Use the calculated sizes/strides/offsets to record the data movement
+                            # caused by the above call to npu_dma_memcpy_nd.
+                            # This line does not change MLIR output at all.
+                            A_taps.append(
+                                TensorAccessPattern(
+                                    (M, K),
+                                    offset=A_offset,
+                                    sizes=A_sizes,
+                                    strides=A_strides,
+                                )
+                            )
+
+                            # B input transfer:
+                            # Transfer the first a (n)-wide block of columns of B,
+                            # Then transfer the (n_aie_columns)-th such block, and so on.
+                            # Each shim will start at a different column offset.
+                            # For example, shim 0 may transfer the tiles marked 0 below,
+                            # and shim 1 may transfer the tiles marked 1.
+                            #
+                            #             N
+                            #      ----------------
+                            #     |0011    0011    |
+                            #     |0011    0011    |
+                            #     |0011    0011    |
+                            # K   |0011    0011    |
+                            #     |0011    0011    |
+                            #     |0011    0011    |
+                            #     |0011    0011    |
+                            #     |0011    0011    |
+                            #      ----------------
+                            B_col_offset = col * n if not b_col_maj else col * n * K
+                            if not b_col_maj:
+                                B_sizes = [N // n // n_aie_cols, K // k, k, n]
+                                B_strides = [n * n_aie_cols, k * N, N, 1]
+                            else:
+                                B_sizes = [N // n // n_aie_cols, K // k, n, k]
+                                B_strides = [n * n_aie_cols * K, k, K, 1]
+
+                            npu_dma_memcpy_nd(
+                                metadata=B_l3l2_fifos[col],
+                                bd_id=bd_id_base + 2 * tile_row + 2,
+                                mem=B,
+                                offsets=[0, 0, 0, B_col_offset],
+                                sizes=B_sizes,
+                                strides=B_strides,
+                            )
+                            # Use the calculated sizes/strides/offsets to record the data movement
+                            # caused by the above call to npu_dma_memcpy_nd.
+                            # This line does not change MLIR output at all.
+                            B_taps.append(
+                                TensorAccessPattern(
+                                    (K, N),
+                                    offset=B_col_offset,
+                                    sizes=B_sizes,
+                                    strides=B_strides,
+                                )
+                            )
+                    if tb > 0 or (tb == 0 and pingpong > 0):
+                        dma_wait(*C_l2l3_fifos)
+            dma_wait(*C_l2l3_fifos)
 
     if generate_taps:
-        # If generate taps is true, return a representation of tensor access patterns
+        # If generate_taps is true, return a representation of tensor tiles
         # representing all the npu_dma_memcpy_nd runtime sequence operations per input/ouput tensor.
         return (
             TensorAccessSequence.from_taps(A_taps),
             TensorAccessSequence.from_taps(B_taps),
             TensorAccessSequence.from_taps(C_taps),
         )
-
-    # Create the program from the device type and runtime
-    my_program = Program(dev, rt)
-
-    # Place components (assign them resources on the device) and generate an MLIR module
-    module = my_program.resolve_program(SequentialPlacer())
-    return module
 
 
 if __name__ == "__main__":

--- a/src/ggml-hsa/kernels/mul_mat.py
+++ b/src/ggml-hsa/kernels/mul_mat.py
@@ -1,0 +1,509 @@
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+import argparse
+from ml_dtypes import bfloat16
+import numpy as np
+
+from aie.iron import Kernel, ObjectFifo, Program, Runtime, Worker
+from aie.iron.placers import SequentialPlacer
+from aie.iron.device import NPU1Col1, NPU1Col2, NPU1Col4, Tile
+from aie.iron.controlflow import range_
+from aie.helpers.taplib import TensorAccessSequence, TensorTiler2D
+
+dtype_map = {
+    "bf16": bfloat16,
+    "i8": np.int8,
+    "i16": np.int16,
+    "f32": np.float32,
+    "i32": np.int32,
+}
+
+
+def main():
+    argparser = argparse.ArgumentParser(
+        prog="AIE Matrix Multiplication MLIR Design (Whole Array)",
+        description="Emits MLIR code for a matrix multiplication design of the given input size",
+    )
+    argparser.add_argument("-M", type=int, required=True)
+    argparser.add_argument("-K", type=int, required=True)
+    argparser.add_argument("-N", type=int, required=True)
+    argparser.add_argument("-m", type=int, required=True)
+    argparser.add_argument("-k", type=int, required=True)
+    argparser.add_argument("-n", type=int, required=True)
+    argparser.add_argument("--n-aie-cols", type=int, choices=[1, 2, 4], required=True)
+    argparser.add_argument("--b-col-maj", type=int, choices=[0, 1], required=True)
+    argparser.add_argument(
+        "--dtype_in", type=str, choices=["bf16", "i8", "i16"], required=True
+    )
+    argparser.add_argument(
+        "--dtype_out",
+        type=str,
+        choices=["bf16", "i8", "i16", "f32", "i32"],
+        required=True,
+    )
+    argparser.add_argument("--trace_size", type=int, default=0)
+    argparser.add_argument(
+        "--generate-taps",
+        action="store_true",
+        help="Generate TensorAccessPatterns, a Python object to represent each data transfer"
+        "of the input/output matrices. These objects can be used for visualization.",
+    )
+    args = argparser.parse_args()
+    maybe_module = my_matmul(
+        args.M,
+        args.K,
+        args.N,
+        args.m,
+        args.k,
+        args.n,
+        args.n_aie_cols,
+        args.dtype_in,
+        args.dtype_out,
+        args.b_col_maj,
+        args.trace_size,
+        args.generate_taps,
+    )
+    if args.generate_taps:
+        return maybe_module
+    else:
+        print(maybe_module)
+
+
+def ceildiv(a, b):
+    return (a + b - 1) // b
+
+
+def my_matmul(
+    M,
+    K,
+    N,
+    m,
+    k,
+    n,
+    n_aie_cols,
+    dtype_in_str,
+    dtype_out_str,
+    b_col_maj,
+    trace_size,
+    generate_taps=False,
+):
+    n_aie_rows = 4
+    n_aie_cores = n_aie_rows * n_aie_cols
+
+    dtype_in = dtype_map[dtype_in_str]
+    dtype_out = dtype_map[dtype_out_str]
+
+    assert np.issubdtype(dtype_in, np.integer) == np.issubdtype(
+        dtype_out, np.integer
+    ), f"Input dtype ({dtype_in}) and output dtype ({dtype_out}) must either both be integral or both be float"
+    assert (
+        np.dtype(dtype_out).itemsize >= np.dtype(dtype_in).itemsize
+    ), f"Output dtype ({dtype_out}) must be equal or larger to input dtype ({dtype_in})"
+
+    if dtype_in_str == "bf16":
+        r = 4
+        s = 8
+        t = 4
+    elif dtype_in_str == "i8":
+        r = 4
+        s = 8
+        t = 8
+    elif dtype_in_str == "i16":
+        r = 4
+        s = 4
+        t = 4
+
+    # Input matrix A:
+    # Conceptually, we divide input A into (m * n_rows, k)-sized blocks. These
+    # blocks are _broadcast_ across AIE core columns, then _distributed_ across
+    # rows, s.t. each of the n_rows compute cores in a column receives a
+    # contiguous (m, k)-sized block of A.
+    assert (
+        M % (m * n_aie_rows) == 0
+    ), """A must be tileable into (m * n_aie_rows, k)-sized blocks"""
+
+    # Both A and B are tiled in the K dimension into size k.
+    assert K % k == 0
+
+    # Input matrix B:
+    # Conceptually, we do the same as with A, but instead of broadcasting
+    # across columns we broadcast across rows and distribute across columns.
+    assert (
+        N % (n * n_aie_cols) == 0
+    ), """B must be tileable into (k, n * n_aie_cols)-sized blocks"""
+
+    # r, s, t are the dimensions required by the microkernel MAC instructions.
+    assert m % r == 0
+    assert k % s == 0
+    assert n % t == 0
+
+    if b_col_maj:
+        # These assertions are probably too broad.
+        assert m % 32 == 0
+        assert k % 32 == 0
+        assert n % 32 == 0
+
+    # If you get errors during CDO generation due to running out of program
+    # memory, it may be because too much code is generated due to ObjectFIFO
+    # loop unrollings. Reducing the depth to 1 here will work around that at
+    # a big performance cost.
+    fifo_depth = 2
+
+    n_tiles_per_core = (M // m) * (N // n) // n_aie_cores
+
+    n_A_tiles_per_shim = n_aie_rows // n_aie_cols
+
+    dev = None
+    if n_aie_cols == 1:
+        dev = NPU1Col1()
+    elif n_aie_cols == 2:
+        dev = NPU1Col2()
+    elif n_aie_cols == 4:
+        dev = NPU1Col4()
+
+    # These will hold TensorAccessPattern objects that represent the runtime
+    # npu_dma_memcpy_nd operations of this design. They are only used if generate_taps is true
+    A_taps = []
+    B_taps = []
+    C_taps = []
+
+    # Define tensor types
+    A_ty = np.ndarray[(M * K,), np.dtype[dtype_in]]
+    B_ty = np.ndarray[(K * N,), np.dtype[dtype_in]]
+    C_ty = np.ndarray[(M * N,), np.dtype[dtype_out]]
+    A_l2_ty = np.ndarray[(m * k * n_A_tiles_per_shim,), np.dtype[dtype_in]]
+    B_l2_ty = np.ndarray[(k * n,), np.dtype[dtype_in]]
+    C_l2_ty = np.ndarray[(m * n * n_aie_rows,), np.dtype[dtype_out]]
+    A_l1_ty = np.ndarray[(m, k), np.dtype[dtype_in]]
+    B_l1_ty = np.ndarray[(k, n), np.dtype[dtype_in]]
+    C_l1_ty = np.ndarray[(m, n), np.dtype[dtype_out]]
+
+    # AIE Core Function declarations
+    zero_kernel = Kernel(f"zero_{dtype_out_str}", f"mm_{m}x{k}x{n}.o", [C_l1_ty])
+    matmul_vectorized_func_name = (
+        f"matmul_{dtype_in_str}_{dtype_out_str}"
+        if not b_col_maj
+        else f"matmul_{dtype_in_str}_{dtype_out_str}_b_col_maj"
+    )
+    matmul_kernel = Kernel(
+        matmul_vectorized_func_name,
+        f"mm_{m}x{k}x{n}.o",
+        [A_l1_ty, B_l1_ty, C_l1_ty],
+    )
+
+    # Tile declarations as tile[row][col]
+    tiles = [[(col, row) for col in range(0, n_aie_cols)] for row in range(0, 6)]
+    core_tiles = tiles[2:]
+
+    # AIE-array data movement with object fifos
+    A_l3l2_fifos = [None] * n_aie_cols
+    A_l2l1_fifos = [None] * n_aie_rows
+
+    B_l3l2_fifos = [None] * n_aie_cols
+    B_l2l1_fifos = [None] * n_aie_cols
+
+    C_l1l2_fifos = [[None] * n_aie_cols for _ in range(n_aie_rows)]
+    C_l2l3_fifos = [None] * n_aie_cols
+
+    # Input A
+    for col in range(n_aie_cols):
+        A_l3l2_fifos[col] = ObjectFifo(
+            A_l2_ty, name=f"A_L3L2_{col}", default_depth=fifo_depth
+        )
+        # If n_cols == n_rows, n_A_tiles_per_shim is 1 and
+        # this simply links a_l3l2_fifos[col] to a_l2l1_fifos[row] directly,
+        # where col == row.
+        # If n_cols < n_rows, each column receives multiple rows of
+        # tiles; distribute it along rows of AIE cores.
+        start_row = col * n_A_tiles_per_shim
+        stop_row = start_row + n_A_tiles_per_shim
+        of_offsets = [m * k * i for i in range(stop_row - start_row)]
+        dims_to_stream = [
+            [
+                (m // r, r * k),
+                (k // s, s),
+                (r, k),
+                (s, 1),
+            ]
+        ] * (stop_row - start_row)
+        a_tmp_fifos = (
+            A_l3l2_fifos[col]
+            .cons()
+            .split(
+                of_offsets,
+                obj_types=[A_l1_ty] * (stop_row - start_row),
+                names=[f"A_L2L1_{row}" for row in range(start_row, stop_row)],
+                dims_to_stream=dims_to_stream,
+                placement=Tile(col, 1),
+            )
+        )
+
+        for i in range(stop_row - start_row):
+            A_l2l1_fifos[i + start_row] = a_tmp_fifos[i]
+
+        # Input B
+        B_l3l2_fifos[col] = ObjectFifo(
+            B_l2_ty, name=f"B_L3L2_{col}", default_depth=fifo_depth
+        )
+        if b_col_maj:
+            dims_to_stream = [(n // t, t * k), (k // s, s), (t, k), (s, 1)]
+        else:
+            dims_to_stream = [(k // s, s * n), (n // t, t), (s, n), (t, 1)]
+        B_l2l1_fifos[col] = (
+            B_l3l2_fifos[col]
+            .cons()
+            .forward(
+                obj_type=B_l1_ty,
+                name=f"B_L2L1_{col}",
+                dims_to_stream=dims_to_stream,
+                placement=Tile(col, 1),
+            )
+        )
+
+        # Output C
+        C_l2l3_fifos[col] = ObjectFifo(
+            C_l2_ty,
+            name=f"C_L2L3_{col}",
+            default_depth=fifo_depth,
+            dims_to_stream=[(m // r, r * n), (r, t), (n // t, r * t), (t, 1)],
+        )
+        of_offsets = [m * n * i for i in range(n_aie_rows)]
+
+        # join along one column
+        c_tmp_fifos = (
+            C_l2l3_fifos[col]
+            .prod()
+            .join(
+                of_offsets,
+                obj_types=[C_l1_ty] * n_aie_rows,
+                names=[f"C_L1L2_{col}_{row}" for row in range(n_aie_rows)],
+                depths=[fifo_depth] * n_aie_rows,
+                placement=Tile(col, 1),
+            )
+        )
+        for j in range(n_aie_rows):
+            C_l1l2_fifos[j][col] = c_tmp_fifos[j]
+
+    # Tasks for each worker to perform
+    def core_fn(in_a, in_b, out_c, zero, matmul):
+        loop = range(1)  # Workaround for issue #1547
+        if n_tiles_per_core > 1:
+            loop = range_(n_tiles_per_core)
+        for _ in loop:
+            elem_out = out_c.acquire(1)
+            zero(elem_out)
+
+            for _ in range_(K // k):
+                elem_in_a = in_a.acquire(1)
+                elem_in_b = in_b.acquire(1)
+                matmul(elem_in_a, elem_in_b, elem_out)
+                in_a.release(1)
+                in_b.release(1)
+            out_c.release(1)
+
+    # Set up compute tiles
+    workers = []
+    for row in range(n_aie_rows):
+        for col in range(n_aie_cols):
+            tile_col, tile_row = core_tiles[row][col]
+            workers.append(
+                Worker(
+                    core_fn,
+                    [
+                        A_l2l1_fifos[row].cons(),
+                        B_l2l1_fifos[col].cons(),
+                        C_l1l2_fifos[row][col].prod(),
+                        zero_kernel,
+                        matmul_kernel,
+                    ],
+                    placement=Tile(tile_col, tile_row),
+                )
+            )
+
+    # We are limited in the number of BDs. After synchronizing, we can reuse BDs.
+    # We only transfer 6 rows of tiles at once before starting a new transfer block.
+    # tb = transfer block; block of transfers before sync call
+    tb_max_n_rows = 4
+    tb_n_rows = tb_max_n_rows // 2
+
+    # Define tensor access patterns (tiling) for A, B, and C
+    A_tiles = TensorTiler2D.group_tiler(
+        (M, K),  # Size of A matrix
+        (m * n_A_tiles_per_shim, k),  # Size of A (smallest) tile
+        (1, K // k),  # Size of "group" of tiles
+        # Repeat data so can distribute across whole column
+        pattern_repeat=N // n // n_aie_cols,
+    )
+    if b_col_maj:
+        B_tiles = TensorTiler2D.step_tiler(
+            (K, N),  # Size of B matrix
+            (k, n),  # Size of B tile
+            # Number of tiles per transfer in each dimension (whole col, partial row)
+            tile_group_repeats=(K // k // n_aie_cols, N // n),
+            # Contiguous tile group in col, but send every n_aie_cols-th tile in the row
+            tile_group_steps=(n_aie_cols, 1),
+        )
+    else:
+        B_tiles = TensorTiler2D.step_tiler(
+            (K, N),  # Size of B matrix
+            (k, n),  # Size of B tile
+            # Number of tiles per transfer in each dimension (whole col, partial row)
+            tile_group_repeats=(K // k, N // n // n_aie_cols),
+            # Contiguous tile group in col, but send every n_aie_cols-th tile in the row
+            tile_group_steps=(1, n_aie_cols),
+            tile_group_col_major=True,  # Send all tiles in column before moving on to next column
+        )
+    C_tiles = TensorTiler2D.step_tiler(
+        (M, N),  # Size of C matrix
+        (m * n_aie_rows, n),  # Size of C tile
+        # Number of tiles per transfer in each dimension (partial col, partial row)
+        tile_group_repeats=(tb_n_rows, N // n // n_aie_cols),
+        # Collect every n_aie_cols row at a time (mirroring how we sent in B data)
+        tile_group_steps=(1, n_aie_cols),
+    )
+    c_index = 0
+
+    # Runtime operations to move data to/from the AIE-array
+    rt = Runtime()
+    with rt.sequence(A_ty, B_ty, C_ty) as (A, B, C):
+        rt.start(*workers)
+
+        # Task groups will be used to determine when to sync/await/free DMA runtime ops
+        tg = rt.task_group()
+        for tb in range(ceildiv(M // m // n_aie_rows, tb_max_n_rows)):
+            for pingpong in [0, 1]:
+                if c_index >= len(C_tiles):
+                    # May not have pong iteration in some cases
+                    break
+
+                row_base = tb * tb_max_n_rows + pingpong * tb_max_n_rows // 2
+                current_tb_n_rows = min(
+                    [tb_max_n_rows // 2, M // m // n_aie_rows - row_base]
+                )
+
+                for col in range(n_aie_cols):
+
+                    # This line does not change MLIR output at all - it's just for recording data movement
+                    C_taps.append(C_tiles[c_index])
+
+                    # C Output Transfer:
+                    # The smallest transfer unit is a (m*n_aie_rows)-x-(n)-sized sub-tile of the matrix.
+                    # Transfer one such tile for every (n_aie_cols)-th column, evenly spaced,
+                    # then repeat that (tb_n_rows) times for the next contiguous blocks of rows.
+                    # Each shim will start at a different column offset, transferring interleaved
+                    # columns. For example, shim 0 may transfer the blocks marked 0 below, and shim 1
+                    # may transfer the blocks marked 1.
+                    #
+                    #             N
+                    #      ----------------
+                    #     |0011    0011    |
+                    #     |0011    0011    |
+                    #     |0011    0011    |
+                    # M   |0011    0011    |
+                    #     |                |
+                    #     |                |
+                    #     |                |
+                    #     |                |
+                    #      ----------------
+                    rt.drain(
+                        C_l2l3_fifos[col].cons(),
+                        C,
+                        tap=C_tiles[c_index],
+                        wait=True,
+                        task_group=tg,
+                        placement=Tile(col, 0),
+                    )
+                    c_index += 1
+
+                    for tile_row in range(current_tb_n_rows):
+
+                        # A input transfer:
+                        #
+                        # The smallest transfer unit is a (m*n_A_tiles_per_shim)-sized sub-tile of the input matrix.
+                        # Transfer one such tile for every column, contiguously.
+                        # Repeat this transfer with identical tiles a total of (N//n//n_aie_cols) times.
+                        # Each shim transfers the tiles for separate rows. For example, shim 0 may transfer the
+                        # tiles marked 0 below, and shim 1 may transfer the tiles marked 1.
+                        #             K
+                        #      ----------------
+                        #     |0000000000000000|    (repeated N//n//n_aie_cols times)
+                        #     |0000000000000000|
+                        #     |1111111111111111|
+                        # M   |1111111111111111|
+                        #     |                |
+                        #     |                |
+                        #     |                |
+                        #     |                |
+                        #      ----------------
+                        tile_offset = ((row_base + tile_row) * n_aie_cols + col) % len(
+                            A_tiles
+                        )
+
+                        rt.fill(
+                            A_l3l2_fifos[col].prod(),
+                            A,
+                            tap=A_tiles[tile_offset],
+                            task_group=tg,
+                            placement=Tile(col, 0),
+                        )
+                        # Use the calculated sizes/strides/offsets to record the data movement
+                        # caused by the above call to npu_dma_memcpy_nd.
+                        # This line does not change MLIR output at all.
+
+                        # B input transfer:
+                        # Transfer the first a (n)-wide block of columns of B,
+                        # Then transfer the (n_aie_columns)-th such block, and so on.
+                        # Each shim will start at a different column offset.
+                        # For example, shim 0 may transfer the tiles marked 0 below,
+                        # and shim 1 may transfer the tiles marked 1.
+                        #
+                        #             N
+                        #      ----------------
+                        #     |0011    0011    |
+                        #     |0011    0011    |
+                        #     |0011    0011    |
+                        # K   |0011    0011    |
+                        #     |0011    0011    |
+                        #     |0011    0011    |
+                        #     |0011    0011    |
+                        #     |0011    0011    |
+                        #      ----------------
+                        rt.fill(
+                            B_l3l2_fifos[col].prod(),
+                            B,
+                            tap=B_tiles[col],
+                            task_group=tg,
+                            placement=Tile(col, 0),
+                        )
+
+                        # These lines do not change MLIR output at all - they are just for recording data movement
+                        A_taps.append(A_tiles[tile_offset])
+                        B_taps.append(B_tiles[col])
+                if tb > 0 or (tb == 0 and pingpong > 0):
+                    rt.finish_task_group(tg)
+                    tg = rt.task_group()
+        rt.finish_task_group(tg)
+
+    if generate_taps:
+        # If generate taps is true, return a representation of tensor access patterns
+        # representing all the npu_dma_memcpy_nd runtime sequence operations per input/ouput tensor.
+        return (
+            TensorAccessSequence.from_taps(A_taps),
+            TensorAccessSequence.from_taps(B_taps),
+            TensorAccessSequence.from_taps(C_taps),
+        )
+
+    # Create the program from the device type and runtime
+    my_program = Program(dev, rt)
+
+    # Place components (assign them resources on the device) and generate an MLIR module
+    module = my_program.resolve_program(SequentialPlacer())
+    return module
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ggml-hsa/kernels/zero.cc
+++ b/src/ggml-hsa/kernels/zero.cc
@@ -1,0 +1,39 @@
+//===- zero.cc --------------------------------------------000---*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ZERO_CC
+#define ZERO_CC
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <type_traits>
+
+template <typename T, int M, int N>
+void zero_scalar(T *__restrict c) {
+  for (int i = 0; i < M * N; i++) {
+    c[i] = 0;
+  }
+}
+
+template <typename T, int M, int N>
+void zero_vectorized(T *__restrict c) {
+  constexpr int r = 256 / (sizeof(T) * 8); // one 256 bit store unit
+  static_assert((M * N) % r == 0);
+  const aie::vector<T, r> zeros = aie::zeros<T, r>();
+  const T *__restrict c_end = c + M * N;
+  event0();
+  for (; c < c_end; c += r) {
+    aie::store_v(c, zeros);
+  }
+  event1();
+}
+
+#endif

--- a/src/ggml-hsa/mul_mat.cpp
+++ b/src/ggml-hsa/mul_mat.cpp
@@ -4,20 +4,6 @@
 
 bool ggml_hsa_supports_mul_mat(const ggml_hsa_device_info::device_info & dev_info,
                                const ggml_tensor * tensor) {
-    const ggml_tensor * src0 = tensor->src[0];
-    const ggml_tensor * src1 = tensor->src[1];
-    const ggml_tensor * dst = tensor;
-
-    // only contiguous tensors are supported
-    if (!ggml_is_contiguous(src0) || !ggml_is_contiguous(src1) || !ggml_is_contiguous(dst)) {
-        return false;
-    }
-
-    // input and output datatypes need to match
-    if ((src0->type != src1->type) || (src0->type != dst->type)) {
-        return false;
-    }
-
     return ggml_hsa_kernel_exists(dev_info, tensor);
 }
 

--- a/src/ggml-hsa/mul_mat.cpp
+++ b/src/ggml-hsa/mul_mat.cpp
@@ -2,121 +2,63 @@
 
 #include "ggml-impl.h"
 
-#include <Eigen/Dense>
-
-template <typename T>
-ggml_status
-ggml_hsa_mul_mat_impl(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
-    using matrix_type = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
-    auto mat_src0 = matrix_type::Map(static_cast<T *>(src0->data), src0->ne[0], src0->ne[1]);
-    auto mat_src1 = matrix_type::Map(static_cast<T *>(src1->data), src1->ne[0], src1->ne[1]);
-    auto mat_dst = matrix_type::Map(static_cast<T *>(dst->data), dst->ne[0], dst->ne[1]);
-    mat_dst = mat_src0.transpose() * mat_src1;
-    return GGML_STATUS_SUCCESS;
-}
-
-static ggml_status
-ggml_hsa_mul_mat_f32(const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
-    if (src1->type != GGML_TYPE_F32) {
-        GGML_LOG_ERROR("%s: Unsupported type for src1 %s", __func__, ggml_type_name(src1->type));
-        return GGML_STATUS_FAILED;
-    }
-
-    if (dst->type != GGML_TYPE_F32) {
-        GGML_LOG_ERROR("%s: Unsupported type for dst %s", __func__, ggml_type_name(dst->type));
-        return GGML_STATUS_FAILED;
-    }
-
-    using matrix_type = Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic>;
-
-    matrix_type mat_src0;
-    switch (src0->type) {
-        case GGML_TYPE_F16 :
-            {
-                auto tmp = Eigen::Matrix<Eigen::half, Eigen::Dynamic, Eigen::Dynamic>::Map(
-                    static_cast<Eigen::half *>(src0->data), src0->ne[0], src0->ne[1]);
-                mat_src0 = tmp.cast<float>();
-                break;
-            }
-        case GGML_TYPE_F32 :
-            mat_src0 = matrix_type::Map(static_cast<float *>(src0->data), src0->ne[0], src0->ne[1]);
-            break;
-        default :
-            return GGML_STATUS_FAILED;
-    }
-    auto mat_src1 = matrix_type::Map(static_cast<float *>(src1->data), src1->ne[0], src1->ne[1]);
-    auto mat_dst = matrix_type::Map(static_cast<float *>(dst->data), dst->ne[0], dst->ne[1]);
-    mat_dst = mat_src0.transpose() * mat_src1;
-
-    return GGML_STATUS_SUCCESS;
-}
-
-bool ggml_hsa_supports_mul_mat(const ggml_hsa_device_info::device_info & /*dev_info*/,
+bool ggml_hsa_supports_mul_mat(const ggml_hsa_device_info::device_info & dev_info,
                                const ggml_tensor * tensor) {
     const ggml_tensor * src0 = tensor->src[0];
     const ggml_tensor * src1 = tensor->src[1];
     const ggml_tensor * dst = tensor;
 
-    if (ggml_is_transposed(src0) || ggml_is_transposed(src1)) {
-        return false;
-    }
-
-    if ((src0->type) == (src1->type) && (src0->type == dst->type) &&
-        ((src0->type == GGML_TYPE_F16) || (src0->type == GGML_TYPE_F32) ||
-         (src0->type == GGML_TYPE_F64))) {
-        return true;
-    }
-
+    // only contiguous tensors are supported
     if (!ggml_is_contiguous(src0) || !ggml_is_contiguous(src1) || !ggml_is_contiguous(dst)) {
         return false;
     }
 
-    if (((src0->type == GGML_TYPE_F16) || (src0->type == GGML_TYPE_F32)) &&
-        (src1->type == GGML_TYPE_F32) && (dst->type == GGML_TYPE_F32)) {
-        return true;
+    // input and output datatypes need to match
+    if ((src0->type != src1->type) || (src0->type != dst->type)) {
+        return false;
     }
 
-    return false;
+    return ggml_hsa_kernel_exists(dev_info, tensor);
 }
 
-ggml_status ggml_hsa_mul_mat(ggml_backend_hsa_context & /*ctx*/, ggml_tensor * tensor) {
+ggml_status ggml_hsa_mul_mat(ggml_backend_hsa_context & ctx, ggml_tensor * tensor) {
+    auto & info = ggml_hsa_info();
+    auto & dev_info = info.devices[ctx.device];
+
+    GGML_ASSERT(ggml_hsa_supports_mul_mat(dev_info, tensor));
+
     const ggml_tensor * src0 = tensor->src[0];
     const ggml_tensor * src1 = tensor->src[1];
     ggml_tensor * dst = tensor;
 
-    assert(ggml_is_contiguous(src0));
-    assert(ggml_is_contiguous(src1));
-    assert(ggml_is_contiguous(dst));
+    ggml_hsa_aie_kernel kernel;
+    if (auto status = ggml_hsa_find_aie_kernel(ctx, tensor, kernel);
+        status != GGML_STATUS_SUCCESS) {
+        return status;
+    }
 
-    if (ggml_is_transposed(src0) || ggml_is_transposed(src1)) {
-        GGML_LOG_ERROR("%s: %s: matmul on tranposed tensor not supported", __func__,
-                       ggml_op_name(dst->op));
+    const std::int64_t element_count = ggml_nelements(src0);
+    hsa_amd_aie_ert_start_kernel_data_t * cmd_payload = nullptr;
+    if (auto status = hsa_amd_memory_pool_allocate(dev_info.kernarg_memory.memory_pool, 64, 0,
+                                                   reinterpret_cast<void **>(&cmd_payload));
+        status != HSA_STATUS_SUCCESS) {
+        GGML_LOG_ERROR("%s: Could not allocate hsa_amd_aie_ert_start_kernel_data_t (%d)\n",
+                       __func__, status);
         return GGML_STATUS_FAILED;
     }
+    cmd_payload->pdi_addr = kernel.pdi.data; // PDI to use with this command
+    cmd_payload->data[0] = 0x3;              // Transaction opcode
+    cmd_payload->data[1] = 0x0;
+    std::tie(cmd_payload->data[3], cmd_payload->data[2]) = ggml_hsa_addr_to_hilo(kernel.insts.data);
+    cmd_payload->data[4] = static_cast<std::uint32_t>(kernel.insts.size);
+    std::tie(cmd_payload->data[6], cmd_payload->data[5]) = ggml_hsa_addr_to_hilo(src0->data);
+    std::tie(cmd_payload->data[8], cmd_payload->data[7]) = ggml_hsa_addr_to_hilo(src1->data);
+    std::tie(cmd_payload->data[10], cmd_payload->data[9]) = ggml_hsa_addr_to_hilo(dst->data);
+    cmd_payload->data[11] = element_count * sizeof(std::uint32_t);
+    cmd_payload->data[12] = element_count * sizeof(std::uint32_t);
+    cmd_payload->data[13] = element_count * sizeof(std::uint32_t);
 
-    ggml_status status = GGML_STATUS_FAILED;
-    if ((src0->type) == (src1->type) && (src0->type == dst->type)) {
-        switch (src0->type) {
-            case GGML_TYPE_F16 :
-                status = ggml_hsa_mul_mat_impl<Eigen::half>(src0, src1, dst);
-                break;
-            case GGML_TYPE_F32 :
-                status = ggml_hsa_mul_mat_impl<float>(src0, src1, dst);
-                break;
-            case GGML_TYPE_F64 :
-                {
-                    status = ggml_hsa_mul_mat_impl<double>(src0, src1, dst);
-                    break;
-                    default :
-                        GGML_LOG_ERROR("%s: Unsupported type %s", __func__,
-                                       ggml_type_name(dst->type));
-                        status = GGML_STATUS_FAILED;
-                        break;
-                }
-        }
-    } else {
-        status = ggml_hsa_mul_mat_f32(src0, src1, dst);
-    }
+    ggml_hsa_dispatch_patch(ctx, cmd_payload, 12);
 
-    return status;
+    return GGML_STATUS_SUCCESS;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -412,3 +412,12 @@ add_executable(${TEST_TARGET} ${TEST_TARGET}.c)
 target_link_libraries(${TEST_TARGET} PRIVATE ggml)
 add_test(NAME ${TEST_TARGET} COMMAND $<TARGET_FILE:${TEST_TARGET}>)
 set_property(TEST ${TEST_TARGET} PROPERTY ENVIRONMENT "LLVM_PROFILE_FILE=${TEST_TARGET}.profraw")
+
+#
+# test-mul-mat-hsa
+
+set(TEST_TARGET test-mul-mat-hsa)
+add_executable(${TEST_TARGET} ${TEST_TARGET}.cpp)
+target_link_libraries(${TEST_TARGET} PRIVATE ggml)
+add_test(NAME ${TEST_TARGET} COMMAND $<TARGET_FILE:${TEST_TARGET}>)
+set_property(TEST ${TEST_TARGET} PROPERTY ENVIRONMENT "LLVM_PROFILE_FILE=${TEST_TARGET}.profraw")

--- a/tests/test-mul-mat-hsa.cpp
+++ b/tests/test-mul-mat-hsa.cpp
@@ -1,0 +1,300 @@
+#include "ggml.h"
+#include "ggml-cpu.h"
+#include "ggml-alloc.h"
+#include "ggml-backend.h"
+
+#ifdef GGML_USE_CUDA
+#include "ggml-cuda.h"
+#endif
+
+#ifdef GGML_USE_HSA
+#include "ggml-hsa.h"
+#endif
+
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <numeric>
+#include <string>
+#include <vector>
+#include <iostream>
+
+#ifdef GGML_USE_HSA
+#define USE_NPU 1
+#endif
+
+template<typename>
+struct fundamental_to_ggml_type;
+
+template<>
+struct fundamental_to_ggml_type<int16_t> {
+    inline static const auto ggml_type = GGML_TYPE_I16;
+};
+
+template<>
+struct fundamental_to_ggml_type<float> {
+    inline static const auto ggml_type = GGML_TYPE_F32;
+};
+
+struct ggml_tensor * ggml_mul_mat_i16(
+    struct ggml_context * ctx,
+    struct ggml_tensor  * a,
+    struct ggml_tensor  * b) {
+    GGML_ASSERT(!ggml_is_transposed(a));
+
+    const int64_t ne[4] = { a->ne[1], b->ne[1], b->ne[2], b->ne[3] };
+    struct ggml_tensor * result = ggml_new_tensor(ctx, GGML_TYPE_I16, 4, ne);
+
+    result->op     = GGML_OP_MUL_MAT;
+    result->src[0] = a;
+    result->src[1] = b;
+
+    return result;
+}
+
+struct test_model {
+    ggml_tensor * a;
+    ggml_tensor * b;
+    ggml_backend_t backend = NULL;
+    ggml_backend_buffer_t buffer;
+    ggml_context * ctx;
+    std::vector<uint8_t> buf;
+};
+
+template<typename T>
+void load_model(test_model & model, T * a, T * b, int M, int N, int K, bool use_gpu = false) {
+    const auto ggml_type = fundamental_to_ggml_type<T>::ggml_type;
+
+    size_t buffer_size = 0;
+    buffer_size += (M * N) * ggml_type_size(ggml_type); // tensor a
+    buffer_size += (N * K) * ggml_type_size(ggml_type); // tensor b
+    buffer_size += 1024; // overhead
+
+    printf("%s: ggml tensor size    = %d bytes\n", __func__, (int) sizeof(ggml_tensor));
+    printf("%s: backend buffer size = %d bytes\n", __func__, (int) buffer_size);
+
+    int num_tensors = 2;
+    ggml_init_params params {
+            /*.mem_size   =*/ ggml_tensor_overhead() * num_tensors,
+            /*.mem_buffer =*/ NULL,
+            /*.no_alloc   =*/ true,
+    };
+
+    // initialize the backend
+#ifdef GGML_USE_CUDA
+    if (use_gpu) {
+        fprintf(stderr, "%s: using CUDA backend\n", __func__);
+        model.backend = ggml_backend_cuda_init(0);
+        if (!model.backend) {
+            fprintf(stderr, "%s: ggml_backend_cuda_init() failed\n", __func__);
+        }
+    }
+#endif
+
+#ifdef GGML_USE_HSA
+    if (use_gpu) {
+        fprintf(stderr, "%s: using HSA backend\n", __func__);
+        model.backend = ggml_backend_hsa_init(0);
+        if (!model.backend) {
+            fprintf(stderr, "%s: ggml_backend_hsa_init() failed\n", __func__);
+        }
+    }
+#endif
+
+    if(!model.backend) {
+        // fallback to CPU backend
+        model.backend = ggml_backend_cpu_init();
+    }
+
+    model.buffer = ggml_backend_alloc_buffer(model.backend, buffer_size);
+
+    // create context
+    model.ctx = ggml_init(params);
+
+    // create tensors
+    model.a = ggml_new_tensor_2d(model.ctx, ggml_type, K, M);
+    printf("Matrix A: [%i, %i]\n", K, M);
+    model.b = ggml_new_tensor_2d(model.ctx, ggml_type, K, N);
+    printf("Matrix B: [%i, %i]\n", K, N);
+
+    // create a allocator
+    ggml_tallocr alloc = ggml_tallocr_new(model.buffer);
+
+    // alloc memory
+    ggml_tallocr_alloc(&alloc, model.a);
+    ggml_tallocr_alloc(&alloc, model.b);
+
+    // copy data directly to device
+    ggml_backend_tensor_set(model.a, a, 0, ggml_nbytes(model.a));
+    ggml_backend_tensor_set(model.b, b, 0, ggml_nbytes(model.b));
+}
+
+ggml_cgraph * build_graph(test_model& model) {
+    const size_t buf_size = ggml_tensor_overhead()*GGML_DEFAULT_GRAPH_SIZE + ggml_graph_overhead();
+    model.buf.resize(buf_size);
+
+    ggml_init_params params0 = {
+        /*.mem_size   =*/ model.buf.size(),
+        /*.mem_buffer =*/ model.buf.data(),
+        /*.no_alloc   =*/ true, // the tensors will be allocated later by ggml_gallocr_alloc_graph()
+    };
+
+    // create a temporally context to build the graph
+    ggml_context * ctx = ggml_init(params0);
+
+    ggml_cgraph * gf = ggml_new_graph(ctx);
+
+    // zT = x @ yT
+#if USE_NPU
+    // HACK: we don't need to transpose
+    ggml_tensor * c = ggml_mul_mat_i16(ctx, model.a, model.b);
+#else
+    ggml_tensor * b_transposed = ggml_cont(ctx, ggml_transpose(ctx, model.b));
+    ggml_tensor * c_transposed = ggml_mul_mat(ctx, model.a, b_transposed);
+    ggml_tensor * c = ggml_cont(ctx, ggml_transpose(ctx, c_transposed));
+#endif
+
+    // z = (zT)T
+    ggml_build_forward_expand(gf, c);
+
+    // delete the temporally context used to build the graph
+    ggml_free(ctx);
+
+    return gf;
+}
+
+ggml_tensor* compute(test_model & model, ggml_gallocr_t allocr) {
+    ggml_cgraph * gf = build_graph(model);
+
+    // allocate tensors
+    ggml_gallocr_alloc_graph(allocr, gf);
+    int n_threads = 1;
+
+    if (ggml_backend_is_cpu(model.backend)) {
+        ggml_backend_cpu_set_n_threads(model.backend, n_threads);
+    }
+
+    ggml_backend_graph_compute(model.backend, gf);
+
+    ggml_graph_print(gf);
+
+    // in this case, the output tensor is the last one in the graph
+    return ggml_graph_node(gf, -1);
+}
+
+template<typename T>
+void print_matrix(const T * matrix, int rows, int cols) {
+    for (int i = 0; i < rows; i++) {
+        for (int j = 0; j < cols; j++) {
+            std::cout << matrix[i * cols + j] << ' ';
+        }
+        std::cout << '\n';
+    }
+}
+
+template<typename T>
+void make_eye(T * matrix, int rows, int cols) {
+    for (int i = 0; i < rows; i++) {
+        for (int j = 0; j < cols; j++) {
+            matrix[i * cols + j] = (i==j);
+        }
+    }
+}
+
+template<typename T, typename U>
+void gemm(int M, int N, int K,
+          const U * A,
+          const U * B,
+          T * C) {
+    for (int m = 0; m < M; ++m) {
+        for (int n = 0; n < N; ++n) {
+            for (int k = 0; k < K; ++k) {
+                C[m * K + k] += A[m * N + n] * B[n * K + k];
+            }
+        }
+    }
+}
+
+int main()
+{
+#if USE_NPU
+    using value_type = int16_t;
+#else
+    using value_type = float;
+#endif
+
+    const int M = 32, N = 32, K = 32;  // a conv2d expected matrix multiplication
+
+    ggml_time_init();
+
+    // matrix A
+    value_type matrixA[M * K] = {};
+    std::iota(matrixA, std::next(matrixA, M*K), 0);
+
+    // matrix B
+    value_type matrixB[N * K] = {};
+    make_eye(matrixB, N, K);
+
+    matrixB[100] = 10;
+
+    // matrix C
+    value_type matrixC_cpu[M * N] = {};
+    gemm(M, N, K, matrixA, matrixB, matrixC_cpu);
+
+    std::cout << "\nA\n";
+    print_matrix(matrixA, M, K);
+    std::cout << "\nB\n";
+    print_matrix(matrixB, N, K);
+    std::cout << "\nC (CPU)\n";
+    print_matrix(matrixC_cpu, M, N);
+
+#if USE_NPU
+    const bool use_npu = true;
+#else
+    const bool use_npu = false;
+#endif
+
+    test_model model;
+    load_model(model, matrixA, matrixB, M, N, K, use_npu);
+
+    ggml_gallocr_t allocr = ggml_gallocr_new(ggml_backend_get_default_buffer_type(model.backend));
+
+    //create the worst case graph for memory usage estimation
+    ggml_cgraph * gf = build_graph(model);
+
+    // compute the required memory
+    ggml_gallocr_reserve(allocr, gf);
+    size_t mem_size = ggml_gallocr_get_buffer_size(allocr, 0);
+    fprintf(stderr, "%s: compute buffer size: %.2f MB\n", __func__, mem_size/1024.0f/1024.0f);
+
+    ggml_tensor * result = compute(model, allocr);
+
+    std::vector<value_type> matrixC(ggml_nelements(result));
+
+    ggml_backend_tensor_get(result, matrixC.data(), 0, ggml_nbytes(result));
+
+    std::cout << "\nC (GGML)\n";
+    print_matrix(matrixC.data(), M, N);
+
+    printf("\nPerforming ggml_mul_mat test:\n");
+
+    bool passed = true;
+    for(int i = 0; i < M * N; i++) {
+        if(matrixC_cpu[i] != matrixC[i]) {
+            passed = false;
+            break;
+        }
+    }
+
+    printf("ggml_mul_mat (%d): %s\n", (int) ggml_nelements(result), passed && (ggml_nelements(result) == M * N) ? "\033[32mPASSED\033[0m" : "\033[31mFAILED\033[0m");
+
+    // free memory
+    ggml_free(model.ctx);
+
+    ggml_backend_buffer_free(model.buffer);
+    ggml_backend_free(model.backend);
+    ggml_gallocr_free(allocr);
+    return 0;
+}


### PR DESCRIPTION
This PR generalizes CMake-based IRON kernel generation and adds GGML_OP_MUL_MAT to the supported operations. The kernels still need to support transposed inputs which will be resolved at a later PR.

Partially resolves #19 