### PR TITLE
HSA tensor extra metadata

### DIFF
--- a/src/ggml-hsa/add.cpp
+++ b/src/ggml-hsa/add.cpp
@@ -17,15 +17,18 @@ ggml_status ggml_hsa_add(ggml_backend_hsa_context & ctx, ggml_tensor * tensor) {
 
     GGML_ASSERT(ggml_hsa_supports_add(dev_info, tensor));
 
+    auto & tensor_extra = *static_cast<ggml_backend_hsa_tensor_extra *>(tensor->extra);
     const ggml_tensor * src0 = tensor->src[0];
     const ggml_tensor * src1 = tensor->src[1];
     ggml_tensor * dst = tensor;
 
-    ggml_hsa_aie_kernel kernel;
-    if (auto status = ggml_hsa_find_aie_kernel(ctx, tensor, kernel);
-        status != GGML_STATUS_SUCCESS) {
-        return status;
+    if (!tensor_extra.kernel.is_valid()) {
+        if (auto status = ggml_hsa_find_aie_kernel(ctx, tensor, tensor_extra.kernel);
+            status != GGML_STATUS_SUCCESS) {
+            return status;
+        }
     }
+    const auto & kernel = tensor_extra.kernel;
 
     const std::size_t packet_dwords = 12;
     const std::int64_t element_count = ggml_nelements(src0);

--- a/src/ggml-hsa/common.hpp
+++ b/src/ggml-hsa/common.hpp
@@ -131,6 +131,11 @@ struct ggml_hsa_aie_kernel {
 };
 
 /**
+ * @brief Tensor extra information.
+ */
+struct ggml_backend_hsa_tensor_extra {};
+
+/**
  * @brief Context for HSA backend operations.
  */
 struct ggml_backend_hsa_context {

--- a/src/ggml-hsa/common.hpp
+++ b/src/ggml-hsa/common.hpp
@@ -112,6 +112,8 @@ const ggml_hsa_device_info & ggml_hsa_info();
 struct ggml_hsa_pdi_buffer {
     std::uint64_t * data{};
     std::size_t size{};
+
+    bool is_valid() const { return data != nullptr; }
 };
 
 /**
@@ -120,6 +122,8 @@ struct ggml_hsa_pdi_buffer {
 struct ggml_hsa_insts_buffer {
     std::uint32_t * data{};
     std::size_t size{};
+
+    bool is_valid() const { return data != nullptr; }
 };
 
 /**
@@ -128,12 +132,19 @@ struct ggml_hsa_insts_buffer {
 struct ggml_hsa_aie_kernel {
     ggml_hsa_pdi_buffer pdi;
     ggml_hsa_insts_buffer insts;
+
+    bool is_valid() const {
+        GGML_ASSERT(pdi.is_valid() == insts.is_valid());
+        return pdi.is_valid();
+    }
 };
 
 /**
  * @brief Tensor extra information.
  */
-struct ggml_backend_hsa_tensor_extra {};
+struct ggml_backend_hsa_tensor_extra {
+    ggml_hsa_aie_kernel kernel; ///< Kernel associated with this tensor.
+};
 
 /**
  * @brief Context for HSA backend operations.

--- a/src/ggml-hsa/kernel_registry.cpp
+++ b/src/ggml-hsa/kernel_registry.cpp
@@ -207,10 +207,15 @@ static ggml_status ggml_hsa_load_insts(hsa_amd_memory_pool_t pool,
 
 bool ggml_hsa_kernel_exists(const ggml_hsa_device_info::device_info & dev_info,
                             const ggml_tensor * tensor) {
+    const auto & tensor_extra = *static_cast<ggml_backend_hsa_tensor_extra *>(tensor->extra);
+    if (tensor_extra.kernel.is_valid()) {
+        return true;
+    }
+
     std::string kernel_name;
     if (auto status = ggml_hsa_create_kernel_name(dev_info, tensor, kernel_name);
         status != GGML_STATUS_SUCCESS) {
-        return status;
+        return false;
     }
 
     fs::path pdi_path;
@@ -224,6 +229,7 @@ ggml_status ggml_hsa_find_aie_kernel(ggml_backend_hsa_context & ctx,
     const auto & info = ggml_hsa_info();
     const auto & dev_info = info.devices[ctx.device];
 
+    // generate kernel name
     std::string kernel_name;
     if (auto status = ggml_hsa_create_kernel_name(dev_info, tensor, kernel_name);
         status != GGML_STATUS_SUCCESS) {

--- a/src/ggml-hsa/kernels.hpp
+++ b/src/ggml-hsa/kernels.hpp
@@ -17,7 +17,8 @@ bool ggml_hsa_kernel_exists(const ggml_hsa_device_info::device_info & dev_info,
  * @brief Finds the AIE agent kernel for the tensor's operation.
  *
  * This function will attempt to load the kernel if not found in @ref
- * ggml_backend_hsa_context::aie_kernels.
+ * ggml_backend_hsa_context::aie_kernels. The kernel is cached in a
+ * data structure in the `extra` member of @ref ggml_tensor.
  *
  * @param ctx backend context
  * @param tensor tensor to find the kernel for

--- a/src/ggml-hsa/kernels/CMakeLists.txt
+++ b/src/ggml-hsa/kernels/CMakeLists.txt
@@ -72,7 +72,7 @@ function(add_aie_iron_kernel TARGET_NAME)
     )
 
     if (DEFINED arg_OBJECT_FILE)
-        set(PEANO_WARNING_FLAGS -Wno-parentheses -Wno-attributes -Wno-macro-redefined)
+        set(PEANO_WARNING_FLAGS -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body)
         set(PEANO_FLAGS -O2 -std=c++20 --target=aie2-none-unknown-elf ${PEANO_WARNING_FLAGS} -DNDEBUG -DBIT_WIDTH=8)
         set(PEANO_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/${arg_SOURCE}")
         string(REPLACE ".py" ".cc" PEANO_SOURCE ${PEANO_SOURCE})


### PR DESCRIPTION
This PR adds a default data structure in ggml_tensor::extra for the HSA backend and caches the kernel in it to avoid costly lookups.

Closes #35 