### PR TITLE
Kernel compilation at tensor initialization

### DIFF
--- a/src/ggml-hsa/.clang-format
+++ b/src/ggml-hsa/.clang-format
@@ -1,4 +1,4 @@
-#  Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
 
 ---
 BasedOnStyle: LLVM

--- a/src/ggml-hsa/CMakeLists.txt
+++ b/src/ggml-hsa/CMakeLists.txt
@@ -1,4 +1,4 @@
-#  Copyright (c) 2024-2025 Advanced Micro Devices, Inc. All Rights Reserved.
+# Copyright (c) 2024-2025 Advanced Micro Devices, Inc. All Rights Reserved.
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 

--- a/src/ggml-hsa/cmake/ggml_hsa_utils.cmake
+++ b/src/ggml-hsa/cmake/ggml_hsa_utils.cmake
@@ -1,4 +1,4 @@
-#  Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
 
 # Creates a target with name TARGET_NAME which copies files to build directory
 #

--- a/src/ggml-hsa/common.hpp
+++ b/src/ggml-hsa/common.hpp
@@ -69,7 +69,7 @@ void ggml_hsa_error(
 /**
  * @brief Returns the number of sources of @p tensor.
  */
-std::int64_t ggml_hsa_nsrcs(const ggml_tensor * tensor);
+std::int64_t ggml_hsa_nsrcs(const ggml_tensor & tensor);
 
 /**
  * @brief Creates a string representation of the tensor shape.

--- a/src/ggml-hsa/common.hpp
+++ b/src/ggml-hsa/common.hpp
@@ -72,6 +72,68 @@ void ggml_hsa_error(
 std::int64_t ggml_hsa_nsrcs(const ggml_tensor * tensor);
 
 /**
+ * @brief Creates a string representation of the tensor shape.
+ *
+ * For a 3D tensor with dimensions `[3,3,4,1]`, the default representation is of the form `3x3x4`.
+ *
+ * @param[in] tensor tensor to output shape for
+ * @param[out] os output stream
+ * @param[in] delim delimiter
+ */
+template <typename OutputStream>
+void ggml_hsa_output_tensor_shape(const ggml_tensor & tensor, OutputStream & os, char delim = 'x') {
+    const auto ndims = ggml_n_dims(&tensor);
+    os << tensor.ne[0];
+    for (std::int32_t i = 1; i < ndims; ++i) {
+        os << delim << tensor.ne[i];
+    }
+}
+
+/**
+ * @brief Creates a string representation of the tensor stride.
+ *
+ * For a 3D tensor with dimensions `[3,3,4,1]`, the default representation is of the form `X,Y,Z`,
+ * where X, Y, Z are the stride in bytes in the first, second, and third dimensions, respectively.
+ *
+ * @param[in] tensor tensor to output stride for
+ * @param[out] os output stream
+ * @param[in] delim delimiter
+ */
+template <typename OutputStream>
+void ggml_hsa_output_tensor_stride(const ggml_tensor & tensor,
+                                   OutputStream & os,
+                                   char delim = ',') {
+    const auto ndims = ggml_n_dims(&tensor);
+    os << tensor.nb[0];
+    for (std::int32_t i = 1; i < ndims; ++i) {
+        os << delim << tensor.nb[i];
+    }
+}
+
+/**
+ * @brief Creates a string representation of the tensor.
+ *
+ * The representation is of the form `DimsDatatypeModifiers`, e.g., `3x3x4f32` for a contiguous 3D
+ * tensor with dimensions `[3,3,4]`.
+ *
+ * @param[in] tensor tensor to output
+ * @param[out] os output stream
+ */
+template <typename OutputStream>
+void ggml_hsa_output_tensor(const ggml_tensor & tensor, OutputStream & os) {
+    ggml_hsa_output_tensor_shape(tensor, os);
+    os << ggml_type_name(tensor.type);
+    if (!ggml_is_contiguous(&tensor)) {
+        os << 'n';
+    }
+}
+
+/**
+ * @brief Creates a kernel name for @p tensor.
+ */
+ggml_status ggml_hsa_create_kernel_name(const ggml_tensor & tensor, std::string & kernel_name);
+
+/**
  * @brief Frees memory allocated using HSA.
  */
 template <typename T>
@@ -283,60 +345,3 @@ ggml_status ggml_hsa_dispatch_kernel(ggml_backend_hsa_context & ctx,
  * @param[in] ctx backend context
  */
 void ggml_hsa_wait_dispatches(ggml_backend_hsa_context & ctx);
-
-/**
- * @brief Creates a string representation of the tensor shape.
- *
- * For a 3D tensor with dimensions `[3,3,4,1]`, the default representation is of the form `3x3x4`.
- *
- * @param[in] tensor tensor to output shape for
- * @param[out] os output stream
- * @param[in] delim delimiter
- */
-template <typename OutputStream>
-void ggml_hsa_output_tensor_shape(const ggml_tensor * tensor, OutputStream & os, char delim = 'x') {
-    const auto ndims = ggml_n_dims(tensor);
-    os << tensor->ne[0];
-    for (std::int32_t i = 1; i < ndims; ++i) {
-        os << delim << tensor->ne[i];
-    }
-}
-
-/**
- * @brief Creates a string representation of the tensor stride.
- *
- * For a 3D tensor with dimensions `[3,3,4,1]`, the default representation is of the form `X,Y,Z`,
- * where X, Y, Z are the stride in bytes in the first, second, and third dimensions, respectively.
- *
- * @param[in] tensor tensor to output stride for
- * @param[out] os output stream
- * @param[in] delim delimiter
- */
-template <typename OutputStream>
-void ggml_hsa_output_tensor_stride(const ggml_tensor * tensor,
-                                   OutputStream & os,
-                                   char delim = ',') {
-    const auto ndims = ggml_n_dims(tensor);
-    os << tensor->nb[0];
-    for (std::int32_t i = 1; i < ndims; ++i) {
-        os << delim << tensor->nb[i];
-    }
-}
-
-/**
- * @brief Creates a string representation of the tensor.
- *
- * The representation is of the form `DimsDatatypeModifiers`, e.g., `3x3x4f32` for a contiguous 3D
- * tensor with dimensions `[3,3,4]`.
- *
- * @param[in] tensor tensor to output
- * @param[out] os output stream
- */
-template <typename OutputStream>
-void ggml_hsa_output_tensor(const ggml_tensor * tensor, OutputStream & os) {
-    ggml_hsa_output_tensor_shape(tensor, os);
-    os << ggml_type_name(tensor->type);
-    if (!ggml_is_contiguous(tensor)) {
-        os << 'n';
-    }
-}

--- a/src/ggml-hsa/common.hpp
+++ b/src/ggml-hsa/common.hpp
@@ -129,9 +129,9 @@ void ggml_hsa_output_tensor(const ggml_tensor & tensor, OutputStream & os) {
 }
 
 /**
- * @brief Creates a kernel name for @p tensor.
+ * @brief Returns a kernel name for @p tensor.
  */
-ggml_status ggml_hsa_create_kernel_name(const ggml_tensor & tensor, std::string & kernel_name);
+std::string ggml_hsa_create_kernel_name(const ggml_tensor & tensor);
 
 /**
  * @brief Frees memory allocated using HSA.

--- a/src/ggml-hsa/ggml-hsa.cpp
+++ b/src/ggml-hsa/ggml-hsa.cpp
@@ -13,6 +13,7 @@
 #include <cstring>
 #include <memory>
 #include <mutex>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -56,6 +57,37 @@ std::int64_t ggml_hsa_nsrcs(const ggml_tensor * tensor) {
     for (; (nsrcs < GGML_MAX_SRC) && (tensor->src[nsrcs] != nullptr); ++nsrcs)
         ;
     return nsrcs;
+}
+
+ggml_status ggml_hsa_create_kernel_name(const ggml_tensor & tensor, std::string & kernel_name) {
+    if ((tensor.op < GGML_OP_NONE) || (tensor.op >= GGML_OP_COUNT)) {
+        GGML_LOG_ERROR("%s: tensor \"%s\" operation index out of bounds (%d >= GGML_OP_COUNT)\n",
+                       __func__, ggml_get_name(&tensor), tensor.op);
+        return GGML_STATUS_FAILED;
+    }
+
+    std::ostringstream oss;
+
+    // name in lowercase
+    std::string_view op_name = ggml_op_desc(&tensor);
+    std::transform(op_name.begin(), op_name.end(), std::ostreambuf_iterator(oss),
+                   [&](char c) { return std::tolower(c); });
+
+    // output tensor
+    oss << '-';
+    ggml_hsa_output_tensor(tensor, oss);
+
+    // input tensors
+    for (std::int32_t i = 0; i < GGML_MAX_SRC; ++i) {
+        if (tensor.src[i] == nullptr) {
+            break;
+        }
+        oss << '-';
+        ggml_hsa_output_tensor(*(tensor.src[i]), oss);
+    }
+
+    kernel_name = oss.str();
+    return GGML_STATUS_SUCCESS;
 }
 
 /**

--- a/src/ggml-hsa/ggml-hsa.cpp
+++ b/src/ggml-hsa/ggml-hsa.cpp
@@ -52,9 +52,9 @@ void ggml_hsa_error(
     GGML_ABORT("HSA error");
 }
 
-std::int64_t ggml_hsa_nsrcs(const ggml_tensor * tensor) {
+std::int64_t ggml_hsa_nsrcs(const ggml_tensor & tensor) {
     std::int64_t nsrcs = 0;
-    for (; (nsrcs < GGML_MAX_SRC) && (tensor->src[nsrcs] != nullptr); ++nsrcs)
+    for (; (nsrcs < GGML_MAX_SRC) && (tensor.src[nsrcs] != nullptr); ++nsrcs)
         ;
     return nsrcs;
 }
@@ -419,7 +419,7 @@ static void ggml_hsa_flatten_tensor(ggml_tensor & tensor) {
 
 ggml_backend_hsa_tensor_extra::ggml_backend_hsa_tensor_extra(
     const ggml_hsa_device_info::device_info & dev_info, const ggml_tensor * parent_tensor) :
-    nsrcs{ggml_hsa_nsrcs(parent_tensor)} {
+    nsrcs{ggml_hsa_nsrcs(*parent_tensor)} {
 
     // check tensor data type
     if (std::find(dev_info.supported_types.begin(), dev_info.supported_types.end(),
@@ -470,7 +470,7 @@ ggml_backend_hsa_tensor_extra::ggml_backend_hsa_tensor_extra(
 
                 total_src_size = src_sizes[1];
 
-                assert(ggml_hsa_nsrcs(&tensor) == nsrcs);
+                assert(ggml_hsa_nsrcs(tensor) == nsrcs);
 
                 create_kernel = true;
             }
@@ -512,7 +512,7 @@ ggml_backend_hsa_tensor_extra::ggml_backend_hsa_tensor_extra(
                         tensor.src[src_idx] = &src[src_idx];
                     }
                 }
-                assert(ggml_hsa_nsrcs(&tensor) == nsrcs);
+                assert(ggml_hsa_nsrcs(tensor) == nsrcs);
 
                 create_kernel = true;
             }

--- a/src/ggml-hsa/host-ops.cpp
+++ b/src/ggml-hsa/host-ops.cpp
@@ -243,7 +243,7 @@ ggml_status ggml_hsa_copy_tensor(const ggml_tensor * src, ggml_tensor * dst) {
 }
 
 ggml_status ggml_hsa_compute_dup(ggml_backend_hsa_context & ctx, ggml_tensor * t) {
-    assert((ggml_hsa_nsrcs(t) == 1) && (t->type == t->src[0]->type) &&
+    assert((ggml_hsa_nsrcs(*t) == 1) && (t->type == t->src[0]->type) &&
            ggml_are_same_shape(t, t->src[0]));
 
     auto * src = t->src[0];
@@ -264,7 +264,7 @@ ggml_status ggml_hsa_compute_dup(ggml_backend_hsa_context & ctx, ggml_tensor * t
 }
 
 ggml_status ggml_hsa_compute_cpy(ggml_backend_hsa_context & ctx, ggml_tensor * t) {
-    assert((ggml_hsa_nsrcs(t) == 2) && (ggml_nelements(t->src[0]) == ggml_nelements(t->src[1])));
+    assert((ggml_hsa_nsrcs(*t) == 2) && (ggml_nelements(t->src[0]) == ggml_nelements(t->src[1])));
 
     auto * src = t->src[0];
     auto * dst = t->src[1];
@@ -275,7 +275,7 @@ ggml_status ggml_hsa_compute_cpy(ggml_backend_hsa_context & ctx, ggml_tensor * t
 }
 
 ggml_status ggml_hsa_compute_cont(ggml_backend_hsa_context & ctx, ggml_tensor * t) {
-    assert((ggml_hsa_nsrcs(t) == 1) && (t->type == t->src[0]->type) &&
+    assert((ggml_hsa_nsrcs(*t) == 1) && (t->type == t->src[0]->type) &&
            (ggml_nelements(t) == ggml_nelements(t->src[0])) && ggml_is_contiguous(t));
 
     auto * src = t->src[0];

--- a/src/ggml-hsa/iron/CMakeLists.txt
+++ b/src/ggml-hsa/iron/CMakeLists.txt
@@ -1,4 +1,4 @@
-#  Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
 
 include(ggml_hsa_utils)
 

--- a/src/ggml-hsa/iron/utils/build.py
+++ b/src/ggml-hsa/iron/utils/build.py
@@ -1,5 +1,5 @@
 # compiler.py -*- Python -*-
-#  Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
 
 import importlib.util
 import os

--- a/src/ggml-hsa/iron/utils/tensor_desc.py
+++ b/src/ggml-hsa/iron/utils/tensor_desc.py
@@ -1,5 +1,5 @@
 # tensor_desc.py -*- Python -*-
-#  Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
 
 import numpy as np
 

--- a/src/ggml-hsa/kernel-compiler.cpp
+++ b/src/ggml-hsa/kernel-compiler.cpp
@@ -116,25 +116,25 @@ static auto ggml_backend_hsa_unary_kernel_jit_info = []() {
  * @brief Returns the JIT compilation information for the given operation.
  */
 static const ggml_hsa_aie_jit_kernel_info &
-ggml_hsa_get_kernel_jit_info(const ggml_tensor * tensor) {
-    assert((tensor->op > GGML_OP_NONE) && (tensor->op < GGML_OP_COUNT) &&
+ggml_hsa_get_kernel_jit_info(const ggml_tensor & tensor) {
+    assert((tensor.op > GGML_OP_NONE) && (tensor.op < GGML_OP_COUNT) &&
            "Tensor operation index out of bounds");
 
-    if (tensor->op == GGML_OP_UNARY) {
+    if (tensor.op == GGML_OP_UNARY) {
         // for unary operations, we need to get the specific unary operation type
-        return ggml_backend_hsa_unary_kernel_jit_info[ggml_get_unary_op(tensor)];
+        return ggml_backend_hsa_unary_kernel_jit_info[ggml_get_unary_op(&tensor)];
     }
 
-    return ggml_backend_hsa_kernel_jit_info[tensor->op];
+    return ggml_backend_hsa_kernel_jit_info[tensor.op];
 }
 
 /**
  * @brief Creates a @p py::tuple from the tensor shape.
  */
-static py::tuple ggml_hsa_tensor_ne_as_pytuple(const ggml_tensor * tensor) {
+static py::tuple ggml_hsa_tensor_ne_as_pytuple(const ggml_tensor & tensor) {
     auto shape = py::tuple(GGML_MAX_DIMS);
     for (auto i = 0; i < GGML_MAX_DIMS; ++i) {
-        shape[i] = py::int_(tensor->ne[i]);
+        shape[i] = py::int_(tensor.ne[i]);
     }
     return shape;
 }
@@ -142,16 +142,16 @@ static py::tuple ggml_hsa_tensor_ne_as_pytuple(const ggml_tensor * tensor) {
 /**
  * @brief Creates a @p py::tuple from the tensor strides.
  */
-static py::tuple ggml_hsa_tensor_nb_as_pytuple(const ggml_tensor * tensor) {
+static py::tuple ggml_hsa_tensor_nb_as_pytuple(const ggml_tensor & tensor) {
     auto stride = py::tuple(GGML_MAX_DIMS);
     for (auto i = 0; i < GGML_MAX_DIMS; ++i) {
-        stride[i] = py::int_(tensor->nb[i]);
+        stride[i] = py::int_(tensor.nb[i]);
     }
     return stride;
 }
 
 ggml_status ggml_hsa_compile_kernel(const ggml_hsa_device_info::device_info & dev_info,
-                                    const ggml_tensor * tensor,
+                                    const ggml_tensor & tensor,
                                     const std::string & exported_name,
                                     const std::filesystem::path & output_path) {
     using namespace pybind11::literals;
@@ -173,20 +173,20 @@ ggml_status ggml_hsa_compile_kernel(const ggml_hsa_device_info::device_info & de
         // convert a GGML tensor to input and output TensorDesc objects
         auto utils = py::module_::import("utils");
         auto tensor_desc_ctor = utils.attr("tensordesc");
-        const auto src_tensor_count = ggml_hsa_nsrcs(*tensor);
+        const auto src_tensor_count = ggml_hsa_nsrcs(tensor);
         auto input_tensors = py::list(src_tensor_count);
         for (auto i = 0; i < src_tensor_count; ++i) {
-            const auto src_tensor = tensor->src[i];
+            const auto src_tensor = tensor.src[i];
             input_tensors[i] =
                 tensor_desc_ctor("dtype"_a = ggml_type_name(src_tensor->type),
-                                 "shape"_a = ggml_hsa_tensor_ne_as_pytuple(src_tensor),
-                                 "stride"_a = ggml_hsa_tensor_nb_as_pytuple(src_tensor),
+                                 "shape"_a = ggml_hsa_tensor_ne_as_pytuple(*src_tensor),
+                                 "stride"_a = ggml_hsa_tensor_nb_as_pytuple(*src_tensor),
                                  "contiguous"_a = ggml_is_contiguous(src_tensor));
         }
-        auto output_tensor = tensor_desc_ctor("dtype"_a = ggml_type_name(tensor->type),
+        auto output_tensor = tensor_desc_ctor("dtype"_a = ggml_type_name(tensor.type),
                                               "shape"_a = ggml_hsa_tensor_ne_as_pytuple(tensor),
                                               "stride"_a = ggml_hsa_tensor_nb_as_pytuple(tensor),
-                                              "contiguous"_a = ggml_is_contiguous(tensor));
+                                              "contiguous"_a = ggml_is_contiguous(&tensor));
 
         // compile the kernel
         auto iron_compiler = py::module_::import("build");
@@ -198,13 +198,13 @@ ggml_status ggml_hsa_compile_kernel(const ggml_hsa_device_info::device_info & de
             "output_directory"_a = output_directory.string(), "verbose"_a = verbose_compilation);
     } catch (const pybind11::error_already_set & ex) {
         GGML_LOG_ERROR("%s: failed to compile kernel %s for tensor \"%s\" (%s): %s\n", __func__,
-                       exported_name.c_str(), tensor->name, ggml_op_desc(tensor), ex.what());
+                       exported_name.c_str(), tensor.name, ggml_op_desc(&tensor), ex.what());
         return GGML_STATUS_FAILED;
     }
 
     GGML_LOG_INFO("%s: generated kernel %s in %s for tensor \"%s\" (%s)\n", __func__,
-                  exported_name.c_str(), output_directory.c_str(), tensor->name,
-                  ggml_op_desc(tensor));
+                  exported_name.c_str(), output_directory.c_str(), tensor.name,
+                  ggml_op_desc(&tensor));
 
     return GGML_STATUS_SUCCESS;
 }

--- a/src/ggml-hsa/kernel-compiler.cpp
+++ b/src/ggml-hsa/kernel-compiler.cpp
@@ -173,7 +173,7 @@ ggml_status ggml_hsa_compile_kernel(const ggml_hsa_device_info::device_info & de
         // convert a GGML tensor to input and output TensorDesc objects
         auto utils = py::module_::import("utils");
         auto tensor_desc_ctor = utils.attr("tensordesc");
-        const auto src_tensor_count = ggml_hsa_nsrcs(tensor);
+        const auto src_tensor_count = ggml_hsa_nsrcs(*tensor);
         auto input_tensors = py::list(src_tensor_count);
         for (auto i = 0; i < src_tensor_count; ++i) {
             const auto src_tensor = tensor->src[i];

--- a/src/ggml-hsa/kernel-compiler.hpp
+++ b/src/ggml-hsa/kernel-compiler.hpp
@@ -16,6 +16,6 @@
  * @param[in] output_path directory to write kernel to
  */
 ggml_status ggml_hsa_compile_kernel(const ggml_hsa_device_info::device_info & dev_info,
-                                    const ggml_tensor * tensor,
+                                    const ggml_tensor & tensor,
                                     const std::string & kernel_name,
                                     const std::filesystem::path & output_path);

--- a/src/ggml-hsa/kernel-discovery.cpp
+++ b/src/ggml-hsa/kernel-discovery.cpp
@@ -170,7 +170,7 @@ ggml_hsa_load_pdi(hsa_amd_memory_pool_t pool, const fs::path & path, ggml_hsa_pd
         return GGML_STATUS_ALLOC_FAILED;
     }
 
-    buffer = ggml_hsa_pdi_buffer(reinterpret_cast<std::uint64_t *>(ptr));
+    buffer = ggml_hsa_pdi_buffer{reinterpret_cast<std::uint64_t *>(ptr)};
 
     is.read(reinterpret_cast<char *>(buffer.data()), size);
 
@@ -210,8 +210,8 @@ static ggml_status ggml_hsa_load_insts(hsa_amd_memory_pool_t pool,
         return GGML_STATUS_ALLOC_FAILED;
     }
 
-    buffer = ggml_hsa_insts_buffer(reinterpret_cast<std::uint32_t *>(ptr),
-                                   (size / sizeof(std::uint32_t)));
+    buffer = ggml_hsa_insts_buffer{reinterpret_cast<std::uint32_t *>(ptr),
+                                   (size / sizeof(std::uint32_t))};
 
     is.read(reinterpret_cast<char *>(buffer.data()), size);
 

--- a/src/ggml-hsa/kernel-discovery.cpp
+++ b/src/ggml-hsa/kernel-discovery.cpp
@@ -182,14 +182,9 @@ static ggml_status ggml_hsa_load_insts(hsa_amd_memory_pool_t pool,
 }
 
 ggml_status ggml_hsa_create_aie_kernel(const ggml_hsa_device_info::device_info & dev_info,
-                                       const ggml_tensor * tensor,
+                                       const std::string & kernel_name,
+                                       const ggml_tensor & tensor,
                                        ggml_hsa_aie_kernel & kernel) {
-    std::string kernel_name;
-    if (auto status = ggml_hsa_create_kernel_name(*tensor, kernel_name);
-        status != GGML_STATUS_SUCCESS) {
-        return status;
-    }
-
     fs::path pdi_path;
     fs::path insts_path;
 

--- a/src/ggml-hsa/kernel-discovery.cpp
+++ b/src/ggml-hsa/kernel-discovery.cpp
@@ -146,38 +146,6 @@ static bool ggml_hsa_find_kernel_files(const std::string & device_name,
 }
 
 /**
- * @brief Tries to finds and if not found, tries to compile the kernel.
- */
-static ggml_status
-ggml_hsa_find_or_compile_kernel(const ggml_hsa_device_info::device_info & dev_info,
-                                const ggml_tensor * tensor,
-                                const std::string & kernel_name,
-                                fs::path & pdi_path,
-                                fs::path & insts_path) {
-    // search for kernel files
-    if (ggml_hsa_find_kernel_files(dev_info.name, kernel_name, pdi_path, insts_path)) {
-        return GGML_STATUS_SUCCESS;
-    }
-
-#ifdef GGML_HSA_JIT_COMPILE
-    // kernel files not found, compile kernel
-    if (auto status = ggml_hsa_compile_kernel(dev_info, tensor, kernel_name, cached_kernel_dir);
-        status != GGML_STATUS_SUCCESS) {
-        return status;
-    }
-
-    // search for kernel files after compilation
-    if (ggml_hsa_find_kernel_files(dev_info.name, kernel_name, pdi_path, insts_path)) {
-        return GGML_STATUS_SUCCESS;
-    }
-#else
-    GGML_UNUSED(tensor);
-#endif
-
-    return GGML_STATUS_ABORTED;
-}
-
-/**
  * @brief Reads a PDI file from @p path and returns its contents and size in bytes in @p buffer.
  */
 static ggml_status
@@ -193,16 +161,18 @@ ggml_hsa_load_pdi(hsa_amd_memory_pool_t pool, const fs::path & path, ggml_hsa_pd
         GGML_LOG_ERROR("%s: could not get file size for %s\n", __func__, path.c_str());
         return GGML_STATUS_FAILED;
     }
-    if (auto status =
-            hsa_amd_memory_pool_allocate(pool, size, 0, reinterpret_cast<void **>(&buffer.data));
+
+    void * ptr = nullptr;
+    if (auto status = hsa_amd_memory_pool_allocate(pool, size, 0, &ptr);
         status != HSA_STATUS_SUCCESS) {
         GGML_LOG_ERROR("%s: failed to allocate %zu bytes (%s)\n", __func__, size,
                        ggml_hsa_get_status_string(status));
         return GGML_STATUS_ALLOC_FAILED;
     }
 
-    is.read(reinterpret_cast<char *>(buffer.data), size);
-    buffer.size = size;
+    buffer = ggml_hsa_pdi_buffer(reinterpret_cast<std::uint64_t *>(ptr));
+
+    is.read(reinterpret_cast<char *>(buffer.data()), size);
 
     return GGML_STATUS_SUCCESS;
 }
@@ -232,35 +202,23 @@ static ggml_status ggml_hsa_load_insts(hsa_amd_memory_pool_t pool,
         return GGML_STATUS_FAILED;
     }
 
-    if (auto status =
-            hsa_amd_memory_pool_allocate(pool, size, 0, reinterpret_cast<void **>(&buffer.data));
+    void * ptr = nullptr;
+    if (auto status = hsa_amd_memory_pool_allocate(pool, size, 0, &ptr);
         status != HSA_STATUS_SUCCESS) {
         GGML_LOG_ERROR("%s: failed to allocate %zu bytes (%s)\n", __func__, size,
                        ggml_hsa_get_status_string(status));
         return GGML_STATUS_ALLOC_FAILED;
     }
 
-    is.read(reinterpret_cast<char *>(buffer.data), size);
-    buffer.size = size / sizeof(std::uint32_t);
+    buffer = ggml_hsa_insts_buffer(reinterpret_cast<std::uint32_t *>(ptr),
+                                   (size / sizeof(std::uint32_t)));
+
+    is.read(reinterpret_cast<char *>(buffer.data()), size);
 
     return GGML_STATUS_SUCCESS;
 }
 
-bool ggml_hsa_kernel_is_supported(const ggml_hsa_device_info::device_info & dev_info,
-                                  const ggml_tensor * tensor) {
-    std::string kernel_name;
-    if (ggml_hsa_create_kernel_name(tensor, kernel_name) != GGML_STATUS_SUCCESS) {
-        return false;
-    }
-
-    // check if the kernel exists; it will generate the kernel if JIT compilation is enabled
-    fs::path pdi_path;
-    fs::path insts_path;
-    return ggml_hsa_find_or_compile_kernel(dev_info, tensor, kernel_name, pdi_path, insts_path) ==
-           GGML_STATUS_SUCCESS;
-}
-
-ggml_status ggml_hsa_create_aie_kernel(ggml_backend_hsa_context & ctx,
+ggml_status ggml_hsa_create_aie_kernel(const ggml_hsa_device_info::device_info & dev_info,
                                        const ggml_tensor * tensor,
                                        ggml_hsa_aie_kernel & kernel) {
     std::string kernel_name;
@@ -269,61 +227,38 @@ ggml_status ggml_hsa_create_aie_kernel(ggml_backend_hsa_context & ctx,
         return status;
     }
 
-    // check if kernel is blocked
-    if (ctx.blocked_aie_kernels.find(kernel_name) != ctx.blocked_aie_kernels.end()) {
-        // kernel is blocked from being loaded
-        GGML_LOG_WARN("%s: kernel %s is blocked\n", __func__, kernel_name.c_str());
-        return GGML_STATUS_ABORTED;
-    }
-
-    // find kernel in already loaded kernels
-    if (auto it = ctx.aie_kernels.find(kernel_name); it != ctx.aie_kernels.end()) {
-        kernel = it->second;
-        return GGML_STATUS_SUCCESS;
-    }
-
-    const auto & info = ggml_hsa_info();
-    const auto & dev_info = info.devices[ctx.device];
-
-    // kernel not found, search the kernel directories
     fs::path pdi_path;
     fs::path insts_path;
-    if (auto status =
-            ggml_hsa_find_or_compile_kernel(dev_info, tensor, kernel_name, pdi_path, insts_path);
-        status != GGML_STATUS_SUCCESS) {
-        // kernel not found and could not be compiled; block to avoid further compilation attempts
-        ctx.blocked_aie_kernels.insert(kernel_name);
-        return status;
+
+    // search for kernel files
+    if (!ggml_hsa_find_kernel_files(dev_info.name, kernel_name, pdi_path, insts_path)) {
+#ifdef GGML_HSA_JIT_COMPILE
+        // kernel files not found, compile kernel
+        if (auto status = ggml_hsa_compile_kernel(dev_info, tensor, kernel_name, cached_kernel_dir);
+            status != GGML_STATUS_SUCCESS) {
+            return status;
+        }
+
+        // search for kernel files after compilation
+        if (!ggml_hsa_find_kernel_files(dev_info.name, kernel_name, pdi_path, insts_path)) {
+            return GGML_STATUS_FAILED;
+        }
+#else
+        return GGML_STATUS_FAILED;
+#endif
     }
 
     // load PDI and instructions
-    ggml_hsa_aie_kernel tmp_kernel;
-    if (auto status = ggml_hsa_load_pdi(dev_info.dev_memory.memory_pool, pdi_path, tmp_kernel.pdi);
+    if (auto status = ggml_hsa_load_pdi(dev_info.dev_memory.memory_pool, pdi_path, kernel.pdi);
         status != GGML_STATUS_SUCCESS) {
         return status;
     }
 
     if (auto status =
-            ggml_hsa_load_insts(dev_info.dev_memory.memory_pool, insts_path, tmp_kernel.insts);
+            ggml_hsa_load_insts(dev_info.dev_memory.memory_pool, insts_path, kernel.insts);
         status != GGML_STATUS_SUCCESS) {
         return status;
     }
 
-    ctx.aie_kernels.emplace(std::move(kernel_name), tmp_kernel);
-
-    kernel = tmp_kernel;
-
     return GGML_STATUS_SUCCESS;
-}
-
-void ggml_hsa_destroy_aie_kernel(ggml_hsa_aie_kernel & kernel) {
-    if (auto status = hsa_amd_memory_pool_free(kernel.pdi.data); status != HSA_STATUS_SUCCESS) {
-        GGML_LOG_ERROR("%s: error freeing memory (%s)\n", __func__,
-                       ggml_hsa_get_status_string(status));
-    }
-    if (auto status = hsa_amd_memory_pool_free(kernel.insts.data); status != HSA_STATUS_SUCCESS) {
-        GGML_LOG_ERROR("%s: error freeing memory (%s)\n", __func__,
-                       ggml_hsa_get_status_string(status));
-    }
-    kernel = {};
 }

--- a/src/ggml-hsa/kernel-discovery.hpp
+++ b/src/ggml-hsa/kernel-discovery.hpp
@@ -5,6 +5,8 @@
 #include "ggml-hsa/common.hpp"
 #include "ggml.h"
 
+#include <string>
+
 /**
  * @brief Creates the AIE kernel for the tensor's operation.
  *
@@ -14,10 +16,12 @@
  *   -# JIT compile the kernel and store it to the cached kernel directory.
  * If none of the above succeeds, an error message will be returned.
  *
- * @param dev_info[in] device information
+ * @param[in] dev_info device information
+ * @param[in] kernel_name kernel name
  * @param[in] tensor tensor to find the kernel for
  * @param[out] kernel kernel for the operation of @p tensor
  */
 ggml_status ggml_hsa_create_aie_kernel(const ggml_hsa_device_info::device_info & dev_info,
-                                       const ggml_tensor * tensor,
+                                       const std::string & kernel_name,
+                                       const ggml_tensor & tensor,
                                        ggml_hsa_aie_kernel & kernel);

--- a/src/ggml-hsa/kernel-discovery.hpp
+++ b/src/ggml-hsa/kernel-discovery.hpp
@@ -6,38 +6,18 @@
 #include "ggml.h"
 
 /**
- * @brief Returns if the kernel is supported for the device and tensor.
- *
- * @note This function may trigger kernel compilation if JIT is enabled.
- *
- * @param dev_info[in] device information
- * @param tensor[in] tensor to load a kernel for
- */
-bool ggml_hsa_kernel_is_supported(const ggml_hsa_device_info::device_info & dev_info,
-                                  const ggml_tensor * tensor);
-
-/**
  * @brief Creates the AIE kernel for the tensor's operation.
  *
  * This function will try the following until one succeeds:
- *   -# attempt to load the kernel from the @ref ctx kernel cache in @ref
- *      ggml_backend_hsa_context::aie_kernels,
- *   -# load the kernel from disk from the system kernel directory,
- *   -# load the kernel from disk from the user kernel directory,
- *   -# JIT compile the kernel and store it to the user kernel directory.
- * If nothing works, an error message will be returned.
+ *   -# load the kernel from the precompiled kernel directory,
+ *   -# load the kernel from the cached kernel directory,
+ *   -# JIT compile the kernel and store it to the cached kernel directory.
+ * If none of the above succeeds, an error message will be returned.
  *
- * @param[in] ctx backend context
+ * @param dev_info[in] device information
  * @param[in] tensor tensor to find the kernel for
  * @param[out] kernel kernel for the operation of @p tensor
  */
-ggml_status ggml_hsa_create_aie_kernel(ggml_backend_hsa_context & ctx,
+ggml_status ggml_hsa_create_aie_kernel(const ggml_hsa_device_info::device_info & dev_info,
                                        const ggml_tensor * tensor,
                                        ggml_hsa_aie_kernel & kernel);
-
-/**
- * @brief Destroys the kernel.
- *
- * @param[in] kernel kernel to destroy
- */
-void ggml_hsa_destroy_aie_kernel(ggml_hsa_aie_kernel & kernel);


### PR DESCRIPTION
This PR changes the compilation flow such that:
1. kernels are compiled when `ggml_tensor::extra` is allocated for the HSA backend,
2. the logic if a tensor operation is supported is shared between `ggml_backend_buffer_init_tensor` and `ggml_backend_supports_op`, and
3. non-contiguous tensor to contiguous tensor transformations happen before flattening to be able to chain the two operations.
 
