### PR TITLE
Convert FP16 to BF16

### DIFF
--- a/src/ggml-hsa/common.hpp
+++ b/src/ggml-hsa/common.hpp
@@ -240,8 +240,8 @@ const ggml_hsa_device_info::device_info & ggml_hsa_get_device_info(std::int32_t 
 struct ggml_backend_hsa_tensor_extra {
     /// @brief Metadata for a transformed tensor.
     struct tensor_metadata_t {
-        std::size_t size{};          ///< Size of the tensor in bytes.
-        bool convert_fp16_to_bf16{}; ///< Convert FP16 to BF16.
+        std::size_t size{};   ///< Size of the tensor in bytes.
+        bool convert_dtype{}; ///< Convert datatype.
     };
 
     // Parent tensor copy
@@ -254,9 +254,9 @@ struct ggml_backend_hsa_tensor_extra {
     std::array<tensor_metadata_t, GGML_MAX_SRC>
         src_metadata{}; ///< Sizes of the source tensors in bytes. 0 for no copy.
 
-    std::size_t total_src_size{};            ///< Total size of the source tensors in bytes.
-    ggml_hsa_unique_ptr<std::byte> buffer;   ///< Temporary buffer for the tensor data.
     std::shared_ptr<ggml_hsa_kernel> kernel; ///< Kernel associated with the tensor.
+    ggml_hsa_unique_ptr<std::byte> buffer;   ///< Temporary buffer for the tensor data.
+    bool requires_sync{false}; ///< If synchronization is needed due to CPU tensor transformations.
 
     ggml_backend_hsa_tensor_extra(const ggml_hsa_device_info::device_info & dev_info,
                                   const ggml_tensor & parent_tensor);
@@ -272,11 +272,6 @@ struct ggml_backend_hsa_tensor_extra {
      * @brief Allocates storage for the internal tensor.
      */
     ggml_status allocate_internal_storage(const ggml_hsa_device_info::device_info & dev_info);
-
-    /**
-     * @brief Returns if one or more input tensors need to be copied..
-     */
-    bool has_input_tensor_copies() const { return total_src_size > 0; }
 };
 
 /**

--- a/src/ggml-hsa/common.hpp
+++ b/src/ggml-hsa/common.hpp
@@ -195,15 +195,15 @@ struct ggml_hsa_device_info {
      * @brief Information about a single HSA device.
      */
     struct device_info {
-        std::int32_t device{};                  ///< Device ID.
-        hsa_agent_t agent{};                    ///< HSA agent associated with the device.
-        hsa_device_type_t type{};               ///< Agent type.
-        std::string name;                       ///< Agent name.
-        std::vector<ggml_type> supported_types; ///< Device natively supported tensor types.
-        memory_pool_info dev_memory{};          ///< Kernel memory pool.
-        memory_pool_info kernarg_memory{};      ///< Kernel arguments memory pool.
-        memory_pool_info data_memory{};         ///< Data memory pool.
-        std::size_t alignment{256};             ///< Memory alignment requirement for buffers.
+        std::int32_t device{};             ///< Device ID.
+        hsa_agent_t agent{};               ///< HSA agent associated with the device.
+        hsa_device_type_t type{};          ///< Agent type.
+        std::string name;                  ///< Agent name.
+        memory_pool_info dev_memory{};     ///< Kernel memory pool.
+        memory_pool_info kernarg_memory{}; ///< Kernel arguments memory pool.
+        memory_pool_info data_memory{};    ///< Data memory pool.
+        std::size_t alignment{256};        ///< Memory alignment requirement for buffers.
+        bool substitute_fp16_bf16{false};  ///< Use BF16 when FP16 is requested.
         std::unordered_map<std::string, std::shared_ptr<ggml_hsa_kernel>>
             kernels; ///< Cached device kernels.
     };

--- a/src/ggml-hsa/ggml-hsa.cpp
+++ b/src/ggml-hsa/ggml-hsa.cpp
@@ -291,8 +291,7 @@ static hsa_status_t ggml_hsa_find_hsa_agents(hsa_agent_t agent, void * data) {
     dev_info.name = std::string(name);
 
     if (dev_info.name == "aie2" || dev_info.name == "aie2p") {
-        dev_info.supported_types = {GGML_TYPE_F32, GGML_TYPE_I8, GGML_TYPE_I16, GGML_TYPE_I32,
-                                    GGML_TYPE_BF16};
+        dev_info.substitute_fp16_bf16 = true;
     } else {
         GGML_ABORT("%s: Unknown agent \"%s\"\n", __func__, dev_info.name.c_str());
     }
@@ -423,13 +422,6 @@ static void ggml_hsa_flatten_tensor(ggml_tensor & tensor) {
 ggml_backend_hsa_tensor_extra::ggml_backend_hsa_tensor_extra(
     const ggml_hsa_device_info::device_info & dev_info, const ggml_tensor * parent_tensor) :
     nsrcs{ggml_hsa_nsrcs(*parent_tensor)} {
-
-    // check tensor data type
-    if (std::find(dev_info.supported_types.begin(), dev_info.supported_types.end(),
-                  parent_tensor->type) == dev_info.supported_types.end()) {
-        throw std::runtime_error{
-            std::string{"Unsupported tensor type "}.append(ggml_type_name(parent_tensor->type))};
-    }
 
     if (!ggml_hsa_has_trivial_layout(*parent_tensor)) {
         throw std::runtime_error{"Output tensor does not have trivial layout."};

--- a/src/ggml-hsa/ggml-hsa.cpp
+++ b/src/ggml-hsa/ggml-hsa.cpp
@@ -423,6 +423,13 @@ ggml_backend_hsa_tensor_extra::ggml_backend_hsa_tensor_extra(
     const ggml_hsa_device_info::device_info & dev_info, const ggml_tensor & parent_tensor) :
     tensor{parent_tensor}, nsrcs{ggml_hsa_nsrcs(parent_tensor)} {
 
+    // initialize source tensor copies
+    for (auto src_idx = 0; src_idx < nsrcs; ++src_idx) {
+        src[src_idx] = *parent_tensor.src[src_idx];
+        tensor.src[src_idx] = &src[src_idx];
+    }
+    assert(ggml_hsa_nsrcs(tensor) == nsrcs);
+
     if (!ggml_hsa_has_trivial_layout(tensor)) {
         throw std::runtime_error{"Output tensor does not have trivial layout."};
     }
@@ -446,12 +453,9 @@ ggml_backend_hsa_tensor_extra::ggml_backend_hsa_tensor_extra(
             break;
         default:
             {
-                // make non-contiguously allocated source tensors contiguous;
-                // source tensors that do not have a trivial layout will be copied to temporary
-                // storage
+                // make source tensor layouts trivial; source tensors that do not have a trivial
+                // layout will be copied to temporary storage
                 for (auto src_idx = 0; src_idx < nsrcs; ++src_idx) {
-                    src[src_idx] = *parent_tensor.src[src_idx];
-                    tensor.src[src_idx] = &src[src_idx];
                     if (!ggml_hsa_has_trivial_layout(src[src_idx])) {
                         src[src_idx].data = nullptr;
                         ggml_hsa_force_unpermuted(src[src_idx]);
@@ -473,7 +477,7 @@ ggml_backend_hsa_tensor_extra::ggml_backend_hsa_tensor_extra(
                 auto kernel_name = ggml_hsa_create_kernel_name(tensor);
                 kernel = ggml_hsa_get_cached_kernel(kernel_name, dev_info);
                 if (kernel == nullptr) {
-                    // kernel not cached; create a new one
+                    // kernel not in cache; create a new one and store it in the cache
                     if (ggml_hsa_create_kernel(dev_info, kernel_name, tensor, kernel) !=
                         GGML_STATUS_SUCCESS) {
                         throw std::runtime_error{
@@ -485,8 +489,6 @@ ggml_backend_hsa_tensor_extra::ggml_backend_hsa_tensor_extra(
                     }
                     ggml_hsa_cache_kernel(std::move(kernel_name), dev_info.device, kernel);
                 }
-
-                assert(ggml_hsa_nsrcs(tensor) == nsrcs);
             }
             break;
     }

--- a/src/ggml-hsa/host-ops.cpp
+++ b/src/ggml-hsa/host-ops.cpp
@@ -13,53 +13,56 @@
  * This function handles different types of tensors and performs necessary conversions
  * based on the type traits defined for each tensor type.
  */
-template <ggml_type SrcT, ggml_type DstT>
-void ggml_hsa_copy_same_shape_tensors(const ggml_tensor * src, ggml_tensor * dst) {
-    assert(ggml_are_same_shape(src, dst));
+struct ggml_hsa_copy_same_shape_tensors_f {
+    template <ggml_type SrcT, ggml_type DstT = SrcT>
+    void operator()(const ggml_tensor * src, ggml_tensor * dst) {
+        assert(ggml_are_same_shape(src, dst));
 
-    using src_traits = ggml_hsa_type_traits<SrcT>;
-    using dst_traits = ggml_hsa_type_traits<DstT>;
+        using src_traits = ggml_hsa_type_traits<SrcT>;
+        using dst_traits = ggml_hsa_type_traits<DstT>;
 
-    using src_type = typename src_traits::type;
-    using dst_type = typename dst_traits::type;
+        using src_type = typename src_traits::type;
+        using dst_type = typename dst_traits::type;
 
-    for (std::int64_t i03 = 0; i03 < src->ne[3]; ++i03) {
-        for (std::int64_t i02 = 0; i02 < src->ne[2]; ++i02) {
-            for (std::int64_t i01 = 0; i01 < src->ne[1]; ++i01) {
-                for (std::int64_t i00 = 0; i00 < src->ne[0]; ++i00) {
-                    auto src_ptr = reinterpret_cast<const src_type *>(
-                        static_cast<const std::byte *>(src->data) +
-                        (i00 * src->nb[0] + i01 * src->nb[1] + i02 * src->nb[2] +
-                         i03 * src->nb[3]));
-                    auto dst_ptr =
-                        reinterpret_cast<dst_type *>(static_cast<std::byte *>(dst->data) +
-                                                     (i00 * dst->nb[0] + i01 * dst->nb[1] +
-                                                      i02 * dst->nb[2] + i03 * dst->nb[3]));
+        for (std::int64_t i03 = 0; i03 < src->ne[3]; ++i03) {
+            for (std::int64_t i02 = 0; i02 < src->ne[2]; ++i02) {
+                for (std::int64_t i01 = 0; i01 < src->ne[1]; ++i01) {
+                    for (std::int64_t i00 = 0; i00 < src->ne[0]; ++i00) {
+                        auto src_ptr = reinterpret_cast<const src_type *>(
+                            static_cast<const std::byte *>(src->data) +
+                            (i00 * src->nb[0] + i01 * src->nb[1] + i02 * src->nb[2] +
+                             i03 * src->nb[3]));
+                        auto dst_ptr =
+                            reinterpret_cast<dst_type *>(static_cast<std::byte *>(dst->data) +
+                                                         (i00 * dst->nb[0] + i01 * dst->nb[1] +
+                                                          i02 * dst->nb[2] + i03 * dst->nb[3]));
 
-                    if constexpr (SrcT == DstT) {
-                        // no conversion needed
-                        *dst_ptr = *src_ptr;
-                    } else if constexpr (src_traits::is_fundamental && dst_traits::is_fundamental) {
-                        // trivial conversion based on fundamental types
-                        *dst_ptr = static_cast<dst_type>(*src_ptr);
-                    } else if constexpr (src_traits::is_fundamental) {
-                        // conversion using promotion of source type to fp32
-                        auto src_v = static_cast<float>(*src_ptr);
-                        *dst_ptr = dst_traits::from_fp32(src_v);
-                    } else if constexpr (dst_traits::is_fundamental) {
-                        // conversion using promotion of destination type to fp32
-                        auto src_v = src_traits::to_fp32(*src_ptr);
-                        *dst_ptr = static_cast<dst_type>(src_v);
-                    } else {
-                        // conversion using promotion of source and destination types to fp32
-                        auto src_v = src_traits::to_fp32(*src_ptr);
-                        *dst_ptr = dst_traits::from_fp32(src_v);
+                        if constexpr (SrcT == DstT) {
+                            // no conversion needed
+                            *dst_ptr = *src_ptr;
+                        } else if constexpr (src_traits::is_fundamental &&
+                                             dst_traits::is_fundamental) {
+                            // trivial conversion based on fundamental types
+                            *dst_ptr = static_cast<dst_type>(*src_ptr);
+                        } else if constexpr (src_traits::is_fundamental) {
+                            // conversion using promotion of source type to fp32
+                            auto src_v = static_cast<float>(*src_ptr);
+                            *dst_ptr = dst_traits::from_fp32(src_v);
+                        } else if constexpr (dst_traits::is_fundamental) {
+                            // conversion using promotion of destination type to fp32
+                            auto src_v = src_traits::to_fp32(*src_ptr);
+                            *dst_ptr = static_cast<dst_type>(src_v);
+                        } else {
+                            // conversion using promotion of source and destination types to fp32
+                            auto src_v = src_traits::to_fp32(*src_ptr);
+                            *dst_ptr = dst_traits::from_fp32(src_v);
+                        }
                     }
                 }
             }
         }
     }
-}
+};
 
 /**
  * @brief Copies the data from the source tensor to a contiguous destination tensor.
@@ -67,173 +70,124 @@ void ggml_hsa_copy_same_shape_tensors(const ggml_tensor * src, ggml_tensor * dst
  * This function handles different types of tensors and performs necessary conversions
  * based on the type traits defined for each tensor type.
  */
-template <ggml_type SrcT, ggml_type DstT>
-void ggml_hsa_copy_tensor_to_cont_tensor(const ggml_tensor * src, ggml_tensor * dst) {
-    assert((ggml_nelements(src) == ggml_nelements(dst)) && ggml_is_contiguous(dst));
+struct ggml_hsa_copy_tensor_to_cont_tensor_f {
+    template <ggml_type SrcT, ggml_type DstT = SrcT>
+    void operator()(const ggml_tensor * src, ggml_tensor * dst) {
+        assert((ggml_nelements(src) == ggml_nelements(dst)) && ggml_is_contiguous(dst));
 
-    using src_traits = ggml_hsa_type_traits<SrcT>;
-    using dst_traits = ggml_hsa_type_traits<DstT>;
+        using src_traits = ggml_hsa_type_traits<SrcT>;
+        using dst_traits = ggml_hsa_type_traits<DstT>;
 
-    using src_type = typename src_traits::type;
-    using dst_type = typename dst_traits::type;
+        using src_type = typename src_traits::type;
+        using dst_type = typename dst_traits::type;
 
-    auto dst_ptr = static_cast<dst_type *>(dst->data);
+        auto dst_ptr = static_cast<dst_type *>(dst->data);
 
-    std::int64_t id = 0;
-    for (std::int64_t i03 = 0; i03 < src->ne[3]; ++i03) {
-        for (std::int64_t i02 = 0; i02 < src->ne[2]; ++i02) {
-            for (std::int64_t i01 = 0; i01 < src->ne[1]; ++i01) {
-                for (std::int64_t i00 = 0; i00 < src->ne[0]; ++i00) {
-                    auto src_ptr = reinterpret_cast<const src_type *>(
-                        static_cast<const std::byte *>(src->data) +
-                        (i00 * src->nb[0] + i01 * src->nb[1] + i02 * src->nb[2] +
-                         i03 * src->nb[3]));
-                    if constexpr (SrcT == DstT) {
-                        // no conversion needed
-                        dst_ptr[id] = *src_ptr;
-                    } else if constexpr (src_traits::is_fundamental && dst_traits::is_fundamental) {
-                        // trivial conversion based on fundamental types
-                        dst_ptr[id] = static_cast<dst_type>(*src_ptr);
-                    } else if constexpr (src_traits::is_fundamental) {
-                        // conversion using promotion of source type to fp32
-                        auto src_v = static_cast<float>(*src_ptr);
-                        dst_ptr[id] = dst_traits::from_fp32(src_v);
-                    } else if constexpr (dst_traits::is_fundamental) {
-                        // conversion using promotion of destination type to fp32
-                        auto src_v = src_traits::to_fp32(*src_ptr);
-                        dst_ptr[id] = static_cast<dst_type>(src_v);
-                    } else {
-                        // conversion using promotion of source and destination types to fp32
-                        auto src_v = src_traits::to_fp32(*src_ptr);
-                        dst_ptr[id] = dst_traits::from_fp32(src_v);
+        std::int64_t id = 0;
+        for (std::int64_t i03 = 0; i03 < src->ne[3]; ++i03) {
+            for (std::int64_t i02 = 0; i02 < src->ne[2]; ++i02) {
+                for (std::int64_t i01 = 0; i01 < src->ne[1]; ++i01) {
+                    for (std::int64_t i00 = 0; i00 < src->ne[0]; ++i00) {
+                        auto src_ptr = reinterpret_cast<const src_type *>(
+                            static_cast<const std::byte *>(src->data) +
+                            (i00 * src->nb[0] + i01 * src->nb[1] + i02 * src->nb[2] +
+                             i03 * src->nb[3]));
+                        if constexpr (SrcT == DstT) {
+                            // no conversion needed
+                            dst_ptr[id] = *src_ptr;
+                        } else if constexpr (src_traits::is_fundamental &&
+                                             dst_traits::is_fundamental) {
+                            // trivial conversion based on fundamental types
+                            dst_ptr[id] = static_cast<dst_type>(*src_ptr);
+                        } else if constexpr (src_traits::is_fundamental) {
+                            // conversion using promotion of source type to fp32
+                            auto src_v = static_cast<float>(*src_ptr);
+                            dst_ptr[id] = dst_traits::from_fp32(src_v);
+                        } else if constexpr (dst_traits::is_fundamental) {
+                            // conversion using promotion of destination type to fp32
+                            auto src_v = src_traits::to_fp32(*src_ptr);
+                            dst_ptr[id] = static_cast<dst_type>(src_v);
+                        } else {
+                            // conversion using promotion of source and destination types to fp32
+                            auto src_v = src_traits::to_fp32(*src_ptr);
+                            dst_ptr[id] = dst_traits::from_fp32(src_v);
+                        }
+                        ++id;
                     }
-                    ++id;
                 }
             }
         }
     }
-}
-
-/**
- * @brief Function object of @ref ggml_hsa_copy_same_shape_tensors.
- */
-struct gggml_hsa_copy_same_shape_tensors_f {
-    template <ggml_type T, ggml_type U = T>
-    void operator()(const ggml_tensor * src, ggml_tensor * dst) {
-        ggml_hsa_copy_same_shape_tensors<T, U>(src, dst);
-    }
 };
 
 /**
- * @brief Function object of @ref ggml_hsa_copy_tensor_to_cont_tensor.
- */
-struct ggml_hsa_copy_tensor_to_cont_tensor_f {
-    template <ggml_type T, ggml_type U = T>
-    void operator()(const ggml_tensor * src, ggml_tensor * dst) {
-        ggml_hsa_copy_tensor_to_cont_tensor<T, U>(src, dst);
-    }
-};
-
-/**
- * @brief Dispatches the operation based on the tensor type.
+ * @brief Assigns @p src to @p dst using @p f as the copy operation.
  */
 template <typename F>
-ggml_status ggml_hsa_dispatch(F && f, const ggml_tensor * src, ggml_tensor * dst) {
-    if (src->type == dst->type) {
-        switch (src->type) {
-            case GGML_TYPE_F32:
-                std::forward<F>(f).template operator()<GGML_TYPE_F32>(src, dst);
-                return GGML_STATUS_SUCCESS;
-            case GGML_TYPE_F16:
-                std::forward<F>(f).template operator()<GGML_TYPE_F16>(src, dst);
-                return GGML_STATUS_SUCCESS;
-            case GGML_TYPE_I8:
-                std::forward<F>(f).template operator()<GGML_TYPE_I8>(src, dst);
-                return GGML_STATUS_SUCCESS;
-            case GGML_TYPE_I16:
-                std::forward<F>(f).template operator()<GGML_TYPE_I16>(src, dst);
-                return GGML_STATUS_SUCCESS;
-            case GGML_TYPE_I32:
-                std::forward<F>(f).template operator()<GGML_TYPE_I32>(src, dst);
-                return GGML_STATUS_SUCCESS;
-            case GGML_TYPE_BF16:
-                std::forward<F>(f).template operator()<GGML_TYPE_BF16>(src, dst);
-                return GGML_STATUS_SUCCESS;
-            default:
-                GGML_LOG_ERROR("%s: unsupported type for tensor \"%s\" (%s)\n", __func__, src->name,
-                               ggml_type_name(src->type));
-                return GGML_STATUS_FAILED;
-        }
-    } else {
-        switch (src->type) {
-            case GGML_TYPE_F32:
-                switch (dst->type) {
-                    case GGML_TYPE_F16:
-                        std::forward<F>(f).template operator()<GGML_TYPE_F32, GGML_TYPE_F16>(src,
-                                                                                             dst);
-                        return GGML_STATUS_SUCCESS;
-                    case GGML_TYPE_I8:
-                        std::forward<F>(f).template operator()<GGML_TYPE_F32, GGML_TYPE_I8>(src,
-                                                                                            dst);
-                        return GGML_STATUS_SUCCESS;
-                    case GGML_TYPE_I16:
-                        std::forward<F>(f).template operator()<GGML_TYPE_F32, GGML_TYPE_I16>(src,
-                                                                                             dst);
-                        return GGML_STATUS_SUCCESS;
-                    case GGML_TYPE_I32:
-                        std::forward<F>(f).template operator()<GGML_TYPE_F32, GGML_TYPE_I32>(src,
-                                                                                             dst);
-                        return GGML_STATUS_SUCCESS;
-                    case GGML_TYPE_BF16:
-                        std::forward<F>(f).template operator()<GGML_TYPE_F32, GGML_TYPE_BF16>(src,
-                                                                                              dst);
-                        return GGML_STATUS_SUCCESS;
-                    default:
-                        GGML_LOG_ERROR("%s: unsupported type for tensor \"%s\" (%s)\n", __func__,
-                                       dst->name, ggml_type_name(dst->type));
-                        return GGML_STATUS_FAILED;
-                }
-            case GGML_TYPE_F16:
-                switch (dst->type) {
-                    case GGML_TYPE_F32:
-                        std::forward<F>(f).template operator()<GGML_TYPE_F16, GGML_TYPE_F32>(src,
-                                                                                             dst);
-                        return GGML_STATUS_SUCCESS;
-                    case GGML_TYPE_BF16:
-                        std::forward<F>(f).template operator()<GGML_TYPE_F16, GGML_TYPE_BF16>(src,
-                                                                                              dst);
-                        return GGML_STATUS_SUCCESS;
-                    default:
-                        GGML_LOG_ERROR("%s: unsupported type for tensor \"%s\" (%s)\n", __func__,
-                                       dst->name, ggml_type_name(dst->type));
-                        return GGML_STATUS_FAILED;
-                }
-            case GGML_TYPE_BF16:
-                switch (dst->type) {
-                    case GGML_TYPE_F32:
-                        std::forward<F>(f).template operator()<GGML_TYPE_BF16, GGML_TYPE_F32>(src,
-                                                                                              dst);
-                        return GGML_STATUS_SUCCESS;
-                    default:
-                        GGML_LOG_ERROR("%s: unsupported type for tensor \"%s\" (%s)\n", __func__,
-                                       dst->name, ggml_type_name(dst->type));
-                        return GGML_STATUS_FAILED;
-                }
-            default:
-                GGML_LOG_ERROR("%s: unsupported type for tensor \"%s\" (%s)\n", __func__, src->name,
-                               ggml_type_name(src->type));
-                return GGML_STATUS_FAILED;
-        }
+ggml_status ggml_hsa_assign(F && f, const ggml_tensor * src, ggml_tensor * dst) {
+    switch (src->type) {
+        case GGML_TYPE_F32:
+            switch (dst->type) {
+                case GGML_TYPE_F32:
+                    std::forward<F>(f).template operator()<GGML_TYPE_F32>(src, dst);
+                    return GGML_STATUS_SUCCESS;
+                case GGML_TYPE_F16:
+                    std::forward<F>(f).template operator()<GGML_TYPE_F32, GGML_TYPE_F16>(src, dst);
+                    return GGML_STATUS_SUCCESS;
+                case GGML_TYPE_BF16:
+                    std::forward<F>(f).template operator()<GGML_TYPE_F32, GGML_TYPE_BF16>(src, dst);
+                    return GGML_STATUS_SUCCESS;
+                default:
+                    GGML_LOG_ERROR("%s: unsupported type for destination tensor \"%s\" (%s)\n",
+                                   __func__, dst->name, ggml_type_name(dst->type));
+                    return GGML_STATUS_FAILED;
+            }
+        case GGML_TYPE_F16:
+            switch (dst->type) {
+                case GGML_TYPE_F32:
+                    std::forward<F>(f).template operator()<GGML_TYPE_F16, GGML_TYPE_F32>(src, dst);
+                    return GGML_STATUS_SUCCESS;
+                case GGML_TYPE_F16:
+                    std::forward<F>(f).template operator()<GGML_TYPE_F16>(src, dst);
+                    return GGML_STATUS_SUCCESS;
+                case GGML_TYPE_BF16:
+                    std::forward<F>(f).template operator()<GGML_TYPE_F16, GGML_TYPE_BF16>(src, dst);
+                    return GGML_STATUS_SUCCESS;
+                default:
+                    GGML_LOG_ERROR("%s: unsupported type for destination tensor \"%s\" (%s)\n",
+                                   __func__, dst->name, ggml_type_name(dst->type));
+                    return GGML_STATUS_FAILED;
+            }
+        case GGML_TYPE_BF16:
+            switch (dst->type) {
+                case GGML_TYPE_F32:
+                    std::forward<F>(f).template operator()<GGML_TYPE_BF16, GGML_TYPE_F32>(src, dst);
+                    return GGML_STATUS_SUCCESS;
+                case GGML_TYPE_F16:
+                    std::forward<F>(f).template operator()<GGML_TYPE_BF16, GGML_TYPE_F16>(src, dst);
+                    return GGML_STATUS_SUCCESS;
+                case GGML_TYPE_BF16:
+                    std::forward<F>(f).template operator()<GGML_TYPE_BF16>(src, dst);
+                    return GGML_STATUS_SUCCESS;
+                default:
+                    GGML_LOG_ERROR("%s: unsupported type for destination tensor \"%s\" (%s)\n",
+                                   __func__, dst->name, ggml_type_name(dst->type));
+                    return GGML_STATUS_FAILED;
+            }
+        default:
+            GGML_LOG_ERROR("%s: unsupported type for source tensor \"%s\" (%s)\n", __func__,
+                           src->name, ggml_type_name(src->type));
+            return GGML_STATUS_FAILED;
     }
 }
 
 ggml_status ggml_hsa_copy_tensor(const ggml_tensor * src, ggml_tensor * dst) {
     if (ggml_is_contiguous(dst)) {
-        return ggml_hsa_dispatch(ggml_hsa_copy_tensor_to_cont_tensor_f{}, src, dst);
+        return ggml_hsa_assign(ggml_hsa_copy_tensor_to_cont_tensor_f{}, src, dst);
     }
 
     if (ggml_are_same_shape(src, dst)) {
-        return ggml_hsa_dispatch(gggml_hsa_copy_same_shape_tensors_f{}, src, dst);
+        return ggml_hsa_assign(ggml_hsa_copy_same_shape_tensors_f{}, src, dst);
     }
 
     GGML_LOG_ERROR("%s: unsupported tensor combination between source \"%s\" (%s) and destination "
@@ -257,10 +211,10 @@ ggml_status ggml_hsa_compute_dup(ggml_backend_hsa_context & ctx, ggml_tensor * t
     ggml_hsa_wait_dispatches(ctx);
 
     if (ggml_is_contiguous(dst)) {
-        return ggml_hsa_dispatch(ggml_hsa_copy_tensor_to_cont_tensor_f{}, src, dst);
+        return ggml_hsa_assign(ggml_hsa_copy_tensor_to_cont_tensor_f{}, src, dst);
     }
 
-    return ggml_hsa_dispatch(gggml_hsa_copy_same_shape_tensors_f{}, src, dst);
+    return ggml_hsa_assign(ggml_hsa_copy_same_shape_tensors_f{}, src, dst);
 }
 
 ggml_status ggml_hsa_compute_cpy(ggml_backend_hsa_context & ctx, ggml_tensor * t) {
@@ -283,5 +237,5 @@ ggml_status ggml_hsa_compute_cont(ggml_backend_hsa_context & ctx, ggml_tensor * 
 
     ggml_hsa_wait_dispatches(ctx);
 
-    return ggml_hsa_dispatch(ggml_hsa_copy_tensor_to_cont_tensor_f{}, src, dst);
+    return ggml_hsa_assign(ggml_hsa_copy_tensor_to_cont_tensor_f{}, src, dst);
 }

--- a/src/ggml-hsa/host-ops.cpp
+++ b/src/ggml-hsa/host-ops.cpp
@@ -3,6 +3,8 @@
 #include "ggml-hsa/host-ops.hpp"
 
 #include <cassert>
+#include <new>
+#include <utility>
 
 #include "ggml-hsa/common.hpp"
 #include "ggml-hsa/type-traits.hpp"
@@ -28,14 +30,14 @@ struct ggml_hsa_copy_same_shape_tensors_f {
             for (std::int64_t i02 = 0; i02 < src->ne[2]; ++i02) {
                 for (std::int64_t i01 = 0; i01 < src->ne[1]; ++i01) {
                     for (std::int64_t i00 = 0; i00 < src->ne[0]; ++i00) {
-                        auto src_ptr = reinterpret_cast<const src_type *>(
+                        auto src_ptr = std::launder(reinterpret_cast<const src_type *>(
                             static_cast<const std::byte *>(src->data) +
                             (i00 * src->nb[0] + i01 * src->nb[1] + i02 * src->nb[2] +
-                             i03 * src->nb[3]));
-                        auto dst_ptr =
+                             i03 * src->nb[3])));
+                        auto dst_ptr = std::launder(
                             reinterpret_cast<dst_type *>(static_cast<std::byte *>(dst->data) +
                                                          (i00 * dst->nb[0] + i01 * dst->nb[1] +
-                                                          i02 * dst->nb[2] + i03 * dst->nb[3]));
+                                                          i02 * dst->nb[2] + i03 * dst->nb[3])));
 
                         if constexpr (SrcT == DstT) {
                             // no conversion needed
@@ -81,17 +83,17 @@ struct ggml_hsa_copy_tensor_to_cont_tensor_f {
         using src_type = typename src_traits::type;
         using dst_type = typename dst_traits::type;
 
-        auto dst_ptr = static_cast<dst_type *>(dst->data);
+        auto dst_ptr = std::launder(static_cast<dst_type *>(dst->data));
 
         std::int64_t id = 0;
         for (std::int64_t i03 = 0; i03 < src->ne[3]; ++i03) {
             for (std::int64_t i02 = 0; i02 < src->ne[2]; ++i02) {
                 for (std::int64_t i01 = 0; i01 < src->ne[1]; ++i01) {
                     for (std::int64_t i00 = 0; i00 < src->ne[0]; ++i00) {
-                        auto src_ptr = reinterpret_cast<const src_type *>(
+                        auto src_ptr = std::launder(reinterpret_cast<const src_type *>(
                             static_cast<const std::byte *>(src->data) +
                             (i00 * src->nb[0] + i01 * src->nb[1] + i02 * src->nb[2] +
-                             i03 * src->nb[3]));
+                             i03 * src->nb[3])));
                         if constexpr (SrcT == DstT) {
                             // no conversion needed
                             dst_ptr[id] = *src_ptr;

--- a/src/ggml-hsa/host-ops.hpp
+++ b/src/ggml-hsa/host-ops.hpp
@@ -9,6 +9,8 @@
 /**
  * @brief Copy the contents of tensor @p src to tensor @p dst.
  *
+ * @warning This function does not synchronize with any device.
+ *
  * @param[in] src tensor to copy from
  * @param[in] dst tensor to copy to
  */

--- a/src/ggml-hsa/iron/kernels/aie2/binary_ops.py
+++ b/src/ggml-hsa/iron/kernels/aie2/binary_ops.py
@@ -59,7 +59,7 @@ def binary_op(device, input_tensor0, input_tensor1, op, output_tensor):
         raise ValueError(
             f"Number of elements ({num_elements}) must be a multiple of {tile_size}."
         )
-    num_elements_div_n = num_elements // tile_size
+    num_tiles = num_elements // tile_size
 
     # AIE-array data movement with object fifos
     input0_tile_ty = np.ndarray[(tile_size,), np.dtype[input_tensor0.dtype]]
@@ -72,7 +72,7 @@ def binary_op(device, input_tensor0, input_tensor1, op, output_tensor):
     # Define a task that will run on a compute tile
     def core_body(of_in0, of_in1, of_out):
         # Number of sub-vector "tile" iterations
-        for _ in range_(num_elements_div_n):
+        for _ in range_(num_tiles):
             elem_in0 = of_in0.acquire(1)
             elem_in1 = of_in1.acquire(1)
             elem_out = of_out.acquire(1)

--- a/src/ggml-hsa/iron/kernels/aie2/unary_ops.cc
+++ b/src/ggml-hsa/iron/kernels/aie2/unary_ops.cc
@@ -38,7 +38,8 @@ void ggml_op_sqrt(const INPUT_DTYPE * __restrict in, OUTPUT_DTYPE * __restrict o
 #ifdef COMPILE_ABS
 
 void ggml_op_abs(const INPUT_DTYPE * __restrict in, OUTPUT_DTYPE * __restrict out, int32_t N) {
-    transform_n(in, N, out, [](auto v) -> OUTPUT_DTYPE { return abs(v); });
+    transform_n(in, N, out,
+                [](auto v) -> OUTPUT_DTYPE { return v < static_cast<INPUT_DTYPE>(0) ? -v : v; });
 }
 
 #endif // COMPILE_ABS
@@ -48,9 +49,9 @@ void ggml_op_abs(const INPUT_DTYPE * __restrict in, OUTPUT_DTYPE * __restrict ou
 void ggml_op_sgn(const INPUT_DTYPE * __restrict in, OUTPUT_DTYPE * __restrict out, int32_t N) {
     transform_n(in, N, out, [](auto v) -> OUTPUT_DTYPE {
         return (v > static_cast<INPUT_DTYPE>(0))
-                   ? static_cast<INPUT_DTYPE>(1)
-                   : ((v < static_cast<INPUT_DTYPE>(0)) ? static_cast<INPUT_DTYPE>(-1)
-                                                        : static_cast<INPUT_DTYPE>(0));
+                   ? static_cast<OUTPUT_DTYPE>(1)
+                   : ((v < static_cast<INPUT_DTYPE>(0)) ? static_cast<OUTPUT_DTYPE>(-1)
+                                                        : static_cast<OUTPUT_DTYPE>(0));
     });
 }
 

--- a/src/ggml-hsa/iron/kernels/aie2/unary_ops.py
+++ b/src/ggml-hsa/iron/kernels/aie2/unary_ops.py
@@ -85,7 +85,7 @@ def apply(
             external_core_fn, fn_args=[of_in.cons(), of_out.prod(), function]
         )
     else:
-        tile_size = max_tile_size(device, input_tensor.dtype, np.size(num_elements))
+        tile_size = max_tile_size(device, input_tensor.dtype, num_elements)
         num_tiles = num_elements // tile_size
 
         # Input / output data movement
@@ -129,7 +129,7 @@ def create_external_function(
     Parameters:
         device (str): Target device.
         op_name (str): Name of the operation.
-        input_tensors (list): List of input tensors.
+        input_tensor: Input tensor.
         output_tensor: Output tensor.
     """
 
@@ -163,7 +163,7 @@ def ggml_op_sqr(device: str, input_tensors: list, output_tensor):
     # function = create_external_function(
     #    device=device,
     #    op_name="sqr",
-    #    input_tensors=input_tensors,
+    #    input_tensor=input_tensors[0],
     #    output_tensor=output_tensor,
     # )
 

--- a/src/ggml-hsa/iron/kernels/aie2/unary_ops.py
+++ b/src/ggml-hsa/iron/kernels/aie2/unary_ops.py
@@ -7,6 +7,7 @@
 # (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
 
 from os import path
+from typing import Callable
 import numpy as np
 
 from aie.iron import (
@@ -23,15 +24,20 @@ from aie.iron.controlflow import range_
 from utils import arch_to_device, max_tile_size
 
 
-def unary_op(device: str, input_tensor, output_tensor, op):
+def apply(
+    device: str,
+    function: Callable | ExternalFunction,
+    input_tensor,
+    output_tensor,
+):
     """
-    Implements output = op(input).
+    Implements output_tensor = op(input_tensor).
 
     Parameters:
         device (str): Target device.
+        function (Callable | ExternalFunction): Unary operator.
         input_tensor: Input tensor.
         output_tensor: Output tensor.
-        op: Unary operator.
     """
 
     if not input_tensor.contiguous or not output_tensor.contiguous:
@@ -42,37 +48,64 @@ def unary_op(device: str, input_tensor, output_tensor, op):
             f"Incompatible input and output shapes ({input_tensor.shape} != {output_tensor.shape})."
         )
 
-    if op.tile_size(0) != op.tile_size(1):
-        raise ValueError(
-            f"Input and output tile sizes do not match ({op.tile_size(0)} != {op.tile_size(1)})."
-        )
-
-    tile_size = op.tile_size(0)
     num_elements = np.size(input_tensor)
-    if num_elements % tile_size != 0:
-        raise ValueError(
-            f"Number of elements ({num_elements}) must be a multiple of {tile_size}."
-        )
-    num_tiles = num_elements // tile_size
-
-    # Input / output data movement
-    input_tile_ty = np.ndarray[(tile_size,), np.dtype[input_tensor.dtype]]
-    output_tile_ty = np.ndarray[(tile_size,), np.dtype[output_tensor.dtype]]
-    of_in = ObjectFifo(input_tile_ty, name="in")
-    of_out = ObjectFifo(output_tile_ty, name="out")
 
     # Task for the core to perform
-    def core_fn(of_in, of_out, op):
-        # Number of sub-vector "tile" iterations
-        for _ in range_(num_tiles):
-            elem_in = of_in.acquire(1)
-            elem_out = of_out.acquire(1)
-            op(elem_in, elem_out, tile_size)
-            of_in.release(1)
-            of_out.release(1)
+    worker = None
+    if isinstance(function, ExternalFunction):
+        if function.tile_size(0) != function.tile_size(1):
+            raise ValueError(
+                f"Input and output tile sizes do not match ({function.tile_size(0)} != {function.tile_size(1)})."
+            )
+        tile_size = function.tile_size(0)
 
-    # Create a worker to perform the task
-    worker = Worker(core_fn, fn_args=[of_in.cons(), of_out.prod(), op])
+        if num_elements % tile_size != 0:
+            raise ValueError(
+                f"Number of elements ({num_elements}) must be a multiple of {tile_size}."
+            )
+        num_tiles = num_elements // tile_size
+
+        # Input / output data movement
+        input_tile_ty = np.ndarray[(tile_size,), np.dtype[input_tensor.dtype]]
+        output_tile_ty = np.ndarray[(tile_size,), np.dtype[output_tensor.dtype]]
+        of_in = ObjectFifo(input_tile_ty, name="in")
+        of_out = ObjectFifo(output_tile_ty, name="out")
+
+        # Task for the core to perform with an external function
+        def external_core_fn(of_in, of_out, function):
+            # Number of sub-vector "tile" iterations
+            for _ in range_(num_tiles):
+                elem_in = of_in.acquire(1)
+                elem_out = of_out.acquire(1)
+                function(elem_in, elem_out, tile_size)
+                of_in.release(1)
+                of_out.release(1)
+
+        worker = Worker(
+            external_core_fn, fn_args=[of_in.cons(), of_out.prod(), function]
+        )
+    else:
+        tile_size = max_tile_size(device, input_tensor.dtype, np.size(num_elements))
+        num_tiles = num_elements // tile_size
+
+        # Input / output data movement
+        input_tile_ty = np.ndarray[(tile_size,), np.dtype[input_tensor.dtype]]
+        output_tile_ty = np.ndarray[(tile_size,), np.dtype[output_tensor.dtype]]
+        of_in = ObjectFifo(input_tile_ty, name="in")
+        of_out = ObjectFifo(output_tile_ty, name="out")
+
+        # Task for the core to perform without an external function
+        def core_fn(of_in, of_out):
+            # Number of sub-vector "tile" iterations
+            for _ in range_(num_tiles):
+                elem_in = of_in.acquire(1)
+                elem_out = of_out.acquire(1)
+                for i in range_(tile_size):
+                    elem_out[i] = function(elem_in[i])
+                of_in.release(1)
+                of_out.release(1)
+
+        worker = Worker(core_fn, fn_args=[of_in.cons(), of_out.prod()])
 
     # Runtime operations to move data to/from the AIE-array
     rt = Runtime()
@@ -88,24 +121,32 @@ def unary_op(device: str, input_tensor, output_tensor, op):
 
 
 def create_external_function(
-    device: str, op_name: str, input_tensors: list, output_tensor
+    device: str, op_name: str, input_tensor, output_tensor
 ) -> ExternalFunction:
-    """Returns an ExternalFunction specification for unary ops."""
+    """
+    Creates an ExternalFunction specification for unary ops.
 
-    tile_size = max_tile_size(device, input_tensors[0].dtype, np.size(input_tensors[0]))
+    Parameters:
+        device (str): Target device.
+        op_name (str): Name of the operation.
+        input_tensors (list): List of input tensors.
+        output_tensor: Output tensor.
+    """
+
+    tile_size = max_tile_size(device, input_tensor.dtype, np.size(input_tensor))
     current_dir = path.dirname(path.realpath(__file__))
     func = ExternalFunction(
         name="ggml_op_" + op_name,
         object_file_name=f"{op_name}_core_function.o",
         source_file=path.join(current_dir, "unary_ops.cc"),
         arg_types=[
-            np.ndarray[(tile_size,), np.dtype[input_tensors[0].dtype]],
+            np.ndarray[(tile_size,), np.dtype[input_tensor.dtype]],
             np.ndarray[(tile_size,), np.dtype[output_tensor.dtype]],
             np.int32,
         ],
         compile_flags=[
             f"-DCOMPILE_{op_name.upper()}=1",
-            f"-DINPUT_DTYPE={dtype_to_str(input_tensors[0].dtype)}",
+            f"-DINPUT_DTYPE={dtype_to_str(input_tensor.dtype)}",
             f"-DOUTPUT_DTYPE={dtype_to_str(output_tensor.dtype)}",
         ],
     )
@@ -114,24 +155,44 @@ def create_external_function(
 
 def ggml_op_sqr(device: str, input_tensors: list, output_tensor):
     """GGML_OP_SQR implementation."""
-    func = create_external_function(
+
+    if len(input_tensors) != 1:
+        raise ValueError("Operation requires exactly one input tensor.")
+
+    # Using a lambda function instead of an external function due to https://github.com/Xilinx/llvm-aie/issues/641
+    # function = create_external_function(
+    #    device=device,
+    #    op_name="sqr",
+    #    input_tensors=input_tensors,
+    #    output_tensor=output_tensor,
+    # )
+
+    return apply(
         device=device,
-        op_name="sqr",
-        input_tensors=input_tensors,
+        function=lambda x: x * x,
+        input_tensor=input_tensors[0],
         output_tensor=output_tensor,
     )
-    return unary_op(device, *input_tensors, output_tensor, func)
 
 
 def ggml_op_sqrt(device: str, input_tensors: list, output_tensor):
     """GGML_OP_SQRT implementation."""
-    func = create_external_function(
+
+    if len(input_tensors) != 1:
+        raise ValueError("Operation requires exactly one input tensor.")
+
+    core_function = create_external_function(
         device=device,
         op_name="sqrt",
-        input_tensors=input_tensors,
+        input_tensor=input_tensors[0],
         output_tensor=output_tensor,
     )
-    return unary_op(device, *input_tensors, output_tensor, func)
+    return apply(
+        device=device,
+        function=core_function,
+        input_tensor=input_tensors[0],
+        output_tensor=output_tensor,
+    )
 
 
 def ggml_op_log(device: str, input_tensors: list, output_tensor):
@@ -151,46 +212,82 @@ def ggml_op_cos(device: str, input_tensors: list, output_tensor):
 
 def ggml_unary_op_abs(device: str, input_tensors: list, output_tensor):
     """GGML_UNARY_OP_ABS implementation."""
-    func = create_external_function(
+
+    if len(input_tensors) != 1:
+        raise ValueError("Operation requires exactly one input tensor.")
+
+    core_function = create_external_function(
         device=device,
         op_name="abs",
-        input_tensors=input_tensors,
+        input_tensor=input_tensors[0],
         output_tensor=output_tensor,
     )
-    return unary_op(device, *input_tensors, output_tensor, func)
+    return apply(
+        device=device,
+        function=core_function,
+        input_tensor=input_tensors[0],
+        output_tensor=output_tensor,
+    )
 
 
 def ggml_unary_op_sgn(device: str, input_tensors: list, output_tensor):
     """GGML_UNARY_OP_SGN implementation."""
-    func = create_external_function(
+
+    if len(input_tensors) != 1:
+        raise ValueError("Operation requires exactly one input tensor.")
+
+    core_function = create_external_function(
         device=device,
         op_name="sgn",
-        input_tensors=input_tensors,
+        input_tensor=input_tensors[0],
         output_tensor=output_tensor,
     )
-    return unary_op(device, *input_tensors, output_tensor, func)
+    return apply(
+        device=device,
+        function=core_function,
+        input_tensor=input_tensors[0],
+        output_tensor=output_tensor,
+    )
 
 
 def ggml_unary_op_neg(device: str, input_tensors: list, output_tensor):
     """GGML_UNARY_OP_NEG implementation."""
-    func = create_external_function(
+
+    if len(input_tensors) != 1:
+        raise ValueError("Operation requires exactly one input tensor.")
+
+    core_function = create_external_function(
         device=device,
         op_name="neg",
-        input_tensors=input_tensors,
+        input_tensor=input_tensors[0],
         output_tensor=output_tensor,
     )
-    return unary_op(device, *input_tensors, output_tensor, func)
+    return apply(
+        device=device,
+        function=core_function,
+        input_tensor=input_tensors[0],
+        output_tensor=output_tensor,
+    )
 
 
 def ggml_unary_op_step(device: str, input_tensors: list, output_tensor):
     """GGML_UNARY_OP_STEP implementation."""
-    func = create_external_function(
+
+    if len(input_tensors) != 1:
+        raise ValueError("Operation requires exactly one input tensor.")
+
+    core_function = create_external_function(
         device=device,
         op_name="step",
-        input_tensors=input_tensors,
+        input_tensor=input_tensors[0],
         output_tensor=output_tensor,
     )
-    return unary_op(device, *input_tensors, output_tensor, func)
+    return apply(
+        device=device,
+        function=core_function,
+        input_tensor=input_tensors[0],
+        output_tensor=output_tensor,
+    )
 
 
 def ggml_unary_op_tanh(device: str, input_tensors: list, output_tensor):
@@ -205,13 +302,22 @@ def ggml_unary_op_elu(device: str, input_tensors: list, output_tensor):
 
 def ggml_unary_op_relu(device: str, input_tensors: list, output_tensor):
     """GGML_UNARY_OP_RELU implementation."""
-    func = create_external_function(
+
+    if len(input_tensors) != 1:
+        raise ValueError("Operation requires exactly one input tensor.")
+
+    core_function = create_external_function(
         device=device,
         op_name="relu",
-        input_tensors=input_tensors,
+        input_tensor=input_tensors[0],
         output_tensor=output_tensor,
     )
-    return unary_op(device, *input_tensors, output_tensor, func)
+    return apply(
+        device=device,
+        function=core_function,
+        input_tensor=input_tensors[0],
+        output_tensor=output_tensor,
+    )
 
 
 def ggml_unary_op_sigmoid(device: str, input_tensors: list, output_tensor):
@@ -236,24 +342,42 @@ def ggml_unary_op_silu(device: str, input_tensors: list, output_tensor):
 
 def ggml_unary_op_hardswish(device: str, input_tensors: list, output_tensor):
     """GGML_UNARY_OP_HARDSWISH implementation."""
-    func = create_external_function(
+
+    if len(input_tensors) != 1:
+        raise ValueError("Operation requires exactly one input tensor.")
+
+    core_function = create_external_function(
         device=device,
         op_name="hardswish",
-        input_tensors=input_tensors,
+        input_tensor=input_tensors[0],
         output_tensor=output_tensor,
     )
-    return unary_op(device, *input_tensors, output_tensor, func)
+    return apply(
+        device=device,
+        function=core_function,
+        input_tensor=input_tensors[0],
+        output_tensor=output_tensor,
+    )
 
 
 def ggml_unary_op_hardsigmoid(device: str, input_tensors: list, output_tensor):
     """GGML_UNARY_OP_HARDSIGMOID implementation."""
-    func = create_external_function(
+
+    if len(input_tensors) != 1:
+        raise ValueError("Operation requires exactly one input tensor.")
+
+    core_function = create_external_function(
         device=device,
         op_name="hardsigmoid",
-        input_tensors=input_tensors,
+        input_tensor=input_tensors[0],
         output_tensor=output_tensor,
     )
-    return unary_op(device, *input_tensors, output_tensor, func)
+    return apply(
+        device=device,
+        function=core_function,
+        input_tensor=input_tensors[0],
+        output_tensor=output_tensor,
+    )
 
 
 def ggml_unary_op_exp(device: str, input_tensors: list, output_tensor):


### PR DESCRIPTION
This PR adds automatic conversion from FP16 to BF16 since the former is not supported by aie2 and aie2p devices. It does in-place conversion of the types on the CPU, which means it is less than optimal. This will be addressed later with graph-level transformations that re-use BF16 values.