### PR TITLE
Update README on how to compile

### DIFF
--- a/src/ggml-hsa/README.md
+++ b/src/ggml-hsa/README.md
@@ -59,7 +59,7 @@ source ./env_setup.sh
 
 To build GGML with HSA support, enable the `GGML_HSA` CMake option. If JIT compilation is desired, also enable the `GGML_HSA_JIT_COMPILE` CMake option.
 
-If a different ROCR installation is preferred, you can point to it setting the `hsa-runtime64_DIR` CMake variable; this will require the ROCR shared library directory to be in your LD_LIBRARY_PATH before any installed ROCm libraries.
+If a different ROCR installation is preferred, you can point to it by setting the `hsa-runtime64_DIR` CMake variable; this will require the ROCR shared library directory to be in your LD_LIBRARY_PATH before any installed ROCm libraries.
 
 ```bash
 cmake -S . -B build -DGGML_HSA=ON -Dhsa-runtime64_DIR=/path/to/rocm/lib/cmake/hsa-runtime64 -DGGML_HSA_JIT_COMPILE=ON \


### PR DESCRIPTION
The ggml-hsa backend compiled successfully under llama.cpp Most useful kernels don't exist yet, but integration works.

Closes #121 