### PR TITLE
Pass op_params argument to kernels in compilation

### DIFF
--- a/src/ggml-hsa/common.hpp
+++ b/src/ggml-hsa/common.hpp
@@ -166,6 +166,19 @@ void ggml_hsa_output_tensor(const ggml_tensor & tensor, OutputStream & os) {
 }
 
 /**
+ * @brief Creates a string representation of the tensor's op_params using a hash.
+ *
+ * @param[in] tensor tensor to output
+ * @param[out] os output stream
+ */
+template <typename OutputStream>
+void ggml_hsa_encode_op_params(const ggml_tensor & tensor, OutputStream & os) {
+    std::string_view bytes(reinterpret_cast<const char *>(tensor.op_params), GGML_MAX_OP_PARAMS);
+    std::size_t hash_value = std::hash<std::string_view>{}(bytes);
+    os << std::hex << hash_value;
+}
+
+/**
  * @brief Returns a kernel name for @p tensor.
  */
 std::string ggml_hsa_create_kernel_name(const ggml_tensor & tensor);

--- a/src/ggml-hsa/kernels/binary_ops.py
+++ b/src/ggml-hsa/kernels/binary_ops.py
@@ -113,7 +113,7 @@ def ggml_op_binary(arch: str, input_tensors: list, function: Callable, output_te
     )
 
 
-def ggml_op_add(arch: str, input_tensors: list, output_tensor):
+def ggml_op_add(arch: str, input_tensors: list, output_tensor, op_params: bytearray):
     """
     GGML_OP_ADD implementation.
 
@@ -121,6 +121,7 @@ def ggml_op_add(arch: str, input_tensors: list, output_tensor):
         arch (str): Target architecture.
         input_tensors (list): List of two input tensors.
         output_tensor: Output tensor.
+        op_params: Operation parameters.
     """
     return ggml_op_binary(
         arch=arch,
@@ -130,7 +131,7 @@ def ggml_op_add(arch: str, input_tensors: list, output_tensor):
     )
 
 
-def ggml_op_sub(arch: str, input_tensors: list, output_tensor):
+def ggml_op_sub(arch: str, input_tensors: list, output_tensor, op_params: bytearray):
     """
     GGML_OP_SUB implementation.
 
@@ -138,6 +139,7 @@ def ggml_op_sub(arch: str, input_tensors: list, output_tensor):
         arch (str): Target architecture.
         input_tensors (list): List of two input tensors.
         output_tensor: Output tensor.
+        op_params: Operation parameters.
     """
     return ggml_op_binary(
         arch=arch,
@@ -147,7 +149,7 @@ def ggml_op_sub(arch: str, input_tensors: list, output_tensor):
     )
 
 
-def ggml_op_mul(arch: str, input_tensors: list, output_tensor):
+def ggml_op_mul(arch: str, input_tensors: list, output_tensor, op_params: bytearray):
     """
     GGML_OP_MUL implementation.
 
@@ -155,6 +157,7 @@ def ggml_op_mul(arch: str, input_tensors: list, output_tensor):
         arch (str): Target architecture.
         input_tensors (list): List of two input tensors.
         output_tensor: Output tensor.
+        op_params: Operation parameters.
     """
     return ggml_op_binary(
         arch=arch,
@@ -164,7 +167,7 @@ def ggml_op_mul(arch: str, input_tensors: list, output_tensor):
     )
 
 
-def ggml_op_div(arch: str, input_tensors: list, output_tensor):
+def ggml_op_div(arch: str, input_tensors: list, output_tensor, op_params: bytearray):
     """
     GGML_OP_DIV implementation.
 
@@ -172,6 +175,7 @@ def ggml_op_div(arch: str, input_tensors: list, output_tensor):
         arch (str): Target architecture.
         input_tensors (list): List of two input tensors.
         output_tensor: Output tensor.
+        op_params: Operation parameters.
     """
     return ggml_op_binary(
         arch=arch,

--- a/src/ggml-hsa/kernels/build.py
+++ b/src/ggml-hsa/kernels/build.py
@@ -155,6 +155,7 @@ def compile_kernel(
     arch: str,
     input_tensors: list[TensorDesc],
     output_tensor: TensorDesc,
+    op_params: bytearray,
     exported_name: str,
     output_directory: os.PathLike,
     verbose: bool = False,
@@ -206,6 +207,7 @@ def compile_kernel(
             "  Kernel source:    %s\n"
             "  Input tensors:    %s\n"
             "  Output tensor:    %s\n"
+            "  Operation parameters: %s\n"
             "  Exported name:    %s\n"
             "  Output directory: %s"
         ),
@@ -215,6 +217,7 @@ def compile_kernel(
         kernel.source_file,
         input_tensors,
         output_tensor,
+        op_params,
         exported_name,
         output_directory,
     )
@@ -236,6 +239,7 @@ def compile_kernel(
         arch=arch,
         input_tensors=input_tensors,
         output_tensor=output_tensor,
+        op_params=op_params,
     )
 
     # compile any external functions

--- a/src/ggml-hsa/kernels/mat_mul.py
+++ b/src/ggml-hsa/kernels/mat_mul.py
@@ -91,7 +91,21 @@ def create_mat_mul_external_functions(
     )
 
 
-def ggml_op_mul_mat(arch: str, input_tensors: list, output_tensor):
+def ggml_op_mul_mat(
+    arch: str, input_tensors: list, output_tensor, op_params: bytearray
+):
+    """
+    Performs matrix multiplication for GGML using the specified architecture.
+
+    Args:
+        arch (str): Target architecture (e.g., "aie2", "aie2p").
+        input_tensors (list): List of two input tensors (A and B).
+        output_tensor: Output tensor (C).
+        op_params (bytearray): Operation-specific parameters as a bytearray.
+
+    Returns:
+        The MLIR module representing the matrix multiplication operation.
+    """
     if len(input_tensors) != 2:
         raise ValueError("Requires two input tensors")
 

--- a/src/ggml-hsa/kernels/unary_ops.py
+++ b/src/ggml-hsa/kernels/unary_ops.py
@@ -149,7 +149,7 @@ def create_external_function(
     return func
 
 
-def ggml_op_sqr(arch: str, input_tensors: list, output_tensor):
+def ggml_op_sqr(arch: str, input_tensors: list, output_tensor, op_params: bytearray):
     """
     GGML_OP_SQR implementation.
 
@@ -157,6 +157,7 @@ def ggml_op_sqr(arch: str, input_tensors: list, output_tensor):
         arch (str): Target architecture.
         input_tensors (list): List of one input tensor.
         output_tensor: Output tensor.
+        op_params: Operation parameters.
     """
 
     core_function = create_external_function(
@@ -173,7 +174,7 @@ def ggml_op_sqr(arch: str, input_tensors: list, output_tensor):
     )
 
 
-def ggml_op_sqrt(arch: str, input_tensors: list, output_tensor):
+def ggml_op_sqrt(arch: str, input_tensors: list, output_tensor, op_params: bytearray):
     """
     GGML_OP_SQRT implementation.
 
@@ -181,11 +182,12 @@ def ggml_op_sqrt(arch: str, input_tensors: list, output_tensor):
         arch (str): Target architecture.
         input_tensors (list): List of one input tensor.
         output_tensor: Output tensor.
+        op_params: Operation parameters.
     """
     raise NotImplementedError
 
 
-def ggml_op_log(arch: str, input_tensors: list, output_tensor):
+def ggml_op_log(arch: str, input_tensors: list, output_tensor, op_params: bytearray):
     """
     GGML_OP_LOG implementation.
 
@@ -193,11 +195,12 @@ def ggml_op_log(arch: str, input_tensors: list, output_tensor):
         arch (str): Target architecture.
         input_tensors (list): List of one input tensor.
         output_tensor: Output tensor.
+        op_params: Operation parameters.
     """
     raise NotImplementedError
 
 
-def ggml_op_sin(arch: str, input_tensors: list, output_tensor):
+def ggml_op_sin(arch: str, input_tensors: list, output_tensor, op_params: bytearray):
     """
     GGML_OP_SIN implementation.
 
@@ -205,11 +208,12 @@ def ggml_op_sin(arch: str, input_tensors: list, output_tensor):
         arch (str): Target architecture.
         input_tensors (list): List of one input tensor.
         output_tensor: Output tensor.
+        op_params: Operation parameters.
     """
     raise NotImplementedError
 
 
-def ggml_op_cos(arch: str, input_tensors: list, output_tensor):
+def ggml_op_cos(arch: str, input_tensors: list, output_tensor, op_params: bytearray):
     """
     GGML_OP_COS implementation.
 
@@ -217,11 +221,14 @@ def ggml_op_cos(arch: str, input_tensors: list, output_tensor):
         arch (str): Target architecture.
         input_tensors (list): List of one input tensor.
         output_tensor: Output tensor.
+        op_params: Operation parameters.
     """
     raise NotImplementedError
 
 
-def ggml_unary_op_abs(arch: str, input_tensors: list, output_tensor):
+def ggml_unary_op_abs(
+    arch: str, input_tensors: list, output_tensor, op_params: bytearray
+):
     """
     GGML_UNARY_OP_ABS implementation.
 
@@ -229,6 +236,7 @@ def ggml_unary_op_abs(arch: str, input_tensors: list, output_tensor):
         arch (str): Target architecture.
         input_tensors (list): List of one input tensor.
         output_tensor: Output tensor.
+        op_params: Operation parameters.
     """
 
     core_function = create_external_function(
@@ -245,7 +253,9 @@ def ggml_unary_op_abs(arch: str, input_tensors: list, output_tensor):
     )
 
 
-def ggml_unary_op_sgn(arch: str, input_tensors: list, output_tensor):
+def ggml_unary_op_sgn(
+    arch: str, input_tensors: list, output_tensor, op_params: bytearray
+):
     """
     GGML_UNARY_OP_SGN implementation.
 
@@ -253,6 +263,7 @@ def ggml_unary_op_sgn(arch: str, input_tensors: list, output_tensor):
         arch (str): Target architecture.
         input_tensors (list): List of one input tensor.
         output_tensor: Output tensor.
+        op_params: Operation parameters.
     """
 
     core_function = create_external_function(
@@ -269,7 +280,9 @@ def ggml_unary_op_sgn(arch: str, input_tensors: list, output_tensor):
     )
 
 
-def ggml_unary_op_neg(arch: str, input_tensors: list, output_tensor):
+def ggml_unary_op_neg(
+    arch: str, input_tensors: list, output_tensor, op_params: bytearray
+):
     """
     GGML_UNARY_OP_NEG implementation.
 
@@ -277,6 +290,7 @@ def ggml_unary_op_neg(arch: str, input_tensors: list, output_tensor):
         arch (str): Target architecture.
         input_tensors (list): List of one input tensor.
         output_tensor: Output tensor.
+        op_params: Operation parameters.
     """
 
     core_function = create_external_function(
@@ -293,7 +307,9 @@ def ggml_unary_op_neg(arch: str, input_tensors: list, output_tensor):
     )
 
 
-def ggml_unary_op_step(arch: str, input_tensors: list, output_tensor):
+def ggml_unary_op_step(
+    arch: str, input_tensors: list, output_tensor, op_params: bytearray
+):
     """
     GGML_UNARY_OP_STEP implementation.
 
@@ -301,6 +317,7 @@ def ggml_unary_op_step(arch: str, input_tensors: list, output_tensor):
         arch (str): Target architecture.
         input_tensors (list): List of one input tensor.
         output_tensor: Output tensor.
+        op_params: Operation parameters.
     """
 
     core_function = create_external_function(
@@ -317,7 +334,9 @@ def ggml_unary_op_step(arch: str, input_tensors: list, output_tensor):
     )
 
 
-def ggml_unary_op_tanh(arch: str, input_tensors: list, output_tensor):
+def ggml_unary_op_tanh(
+    arch: str, input_tensors: list, output_tensor, op_params: bytearray
+):
     """
     GGML_UNARY_OP_TANH implementation.
 
@@ -325,11 +344,14 @@ def ggml_unary_op_tanh(arch: str, input_tensors: list, output_tensor):
         arch (str): Target architecture.
         input_tensors (list): List of one input tensor.
         output_tensor: Output tensor.
+        op_params: Operation parameters.
     """
     raise NotImplementedError
 
 
-def ggml_unary_op_elu(arch: str, input_tensors: list, output_tensor):
+def ggml_unary_op_elu(
+    arch: str, input_tensors: list, output_tensor, op_params: bytearray
+):
     """
     GGML_UNARY_OP_ELU implementation.
 
@@ -337,11 +359,14 @@ def ggml_unary_op_elu(arch: str, input_tensors: list, output_tensor):
         arch (str): Target architecture.
         input_tensors (list): List of one input tensor.
         output_tensor: Output tensor.
+        op_params: Operation parameters.
     """
     raise NotImplementedError
 
 
-def ggml_unary_op_relu(arch: str, input_tensors: list, output_tensor):
+def ggml_unary_op_relu(
+    arch: str, input_tensors: list, output_tensor, op_params: bytearray
+):
     """
     GGML_UNARY_OP_RELU implementation.
 
@@ -349,6 +374,7 @@ def ggml_unary_op_relu(arch: str, input_tensors: list, output_tensor):
         arch (str): Target architecture.
         input_tensors (list): List of one input tensor.
         output_tensor: Output tensor.
+        op_params: Operation parameters.
     """
 
     core_function = create_external_function(
@@ -365,7 +391,9 @@ def ggml_unary_op_relu(arch: str, input_tensors: list, output_tensor):
     )
 
 
-def ggml_unary_op_sigmoid(arch: str, input_tensors: list, output_tensor):
+def ggml_unary_op_sigmoid(
+    arch: str, input_tensors: list, output_tensor, op_params: bytearray
+):
     """
     GGML_UNARY_OP_SIGMOID implementation.
 
@@ -373,11 +401,14 @@ def ggml_unary_op_sigmoid(arch: str, input_tensors: list, output_tensor):
         arch (str): Target architecture.
         input_tensors (list): List of one input tensor.
         output_tensor: Output tensor.
+        op_params: Operation parameters.
     """
     raise NotImplementedError
 
 
-def ggml_unary_op_gelu(arch: str, input_tensors: list, output_tensor):
+def ggml_unary_op_gelu(
+    arch: str, input_tensors: list, output_tensor, op_params: bytearray
+):
     """
     GGML_UNARY_OP_GELU implementation.
 
@@ -385,11 +416,14 @@ def ggml_unary_op_gelu(arch: str, input_tensors: list, output_tensor):
         arch (str): Target architecture.
         input_tensors (list): List of one input tensor.
         output_tensor: Output tensor.
+        op_params: Operation parameters.
     """
     raise NotImplementedError
 
 
-def ggml_unary_op_gelu_quick(arch: str, input_tensors: list, output_tensor):
+def ggml_unary_op_gelu_quick(
+    arch: str, input_tensors: list, output_tensor, op_params: bytearray
+):
     """
     GGML_UNARY_OP_GELU_QUICK implementation.
 
@@ -397,11 +431,14 @@ def ggml_unary_op_gelu_quick(arch: str, input_tensors: list, output_tensor):
         arch (str): Target architecture.
         input_tensors (list): List of one input tensor.
         output_tensor: Output tensor.
+        op_params: Operation parameters.
     """
     raise NotImplementedError
 
 
-def ggml_unary_op_silu(arch: str, input_tensors: list, output_tensor):
+def ggml_unary_op_silu(
+    arch: str, input_tensors: list, output_tensor, op_params: bytearray
+):
     """
     GGML_UNARY_OP_SILU implementation.
 
@@ -409,11 +446,14 @@ def ggml_unary_op_silu(arch: str, input_tensors: list, output_tensor):
         arch (str): Target architecture.
         input_tensors (list): List of one input tensor.
         output_tensor: Output tensor.
+        op_params: Operation parameters.
     """
     raise NotImplementedError
 
 
-def ggml_unary_op_hardswish(arch: str, input_tensors: list, output_tensor):
+def ggml_unary_op_hardswish(
+    arch: str, input_tensors: list, output_tensor, op_params: bytearray
+):
     """
     GGML_UNARY_OP_HARDSWISH implementation.
 
@@ -421,6 +461,7 @@ def ggml_unary_op_hardswish(arch: str, input_tensors: list, output_tensor):
         arch (str): Target architecture.
         input_tensors (list): List of one input tensor.
         output_tensor: Output tensor.
+        op_params: Operation parameters.
     """
 
     core_function = create_external_function(
@@ -437,7 +478,9 @@ def ggml_unary_op_hardswish(arch: str, input_tensors: list, output_tensor):
     )
 
 
-def ggml_unary_op_hardsigmoid(arch: str, input_tensors: list, output_tensor):
+def ggml_unary_op_hardsigmoid(
+    arch: str, input_tensors: list, output_tensor, op_params: bytearray
+):
     """
     GGML_UNARY_OP_HARDSIGMOID implementation.
 
@@ -445,6 +488,7 @@ def ggml_unary_op_hardsigmoid(arch: str, input_tensors: list, output_tensor):
         arch (str): Target architecture.
         input_tensors (list): List of one input tensor.
         output_tensor: Output tensor.
+        op_params: Operation parameters.
     """
 
     core_function = create_external_function(
@@ -461,7 +505,9 @@ def ggml_unary_op_hardsigmoid(arch: str, input_tensors: list, output_tensor):
     )
 
 
-def ggml_unary_op_exp(arch: str, input_tensors: list, output_tensor):
+def ggml_unary_op_exp(
+    arch: str, input_tensors: list, output_tensor, op_params: bytearray
+):
     """
     GGML_UNARY_OP_EXP implementation.
 
@@ -469,11 +515,14 @@ def ggml_unary_op_exp(arch: str, input_tensors: list, output_tensor):
         arch (str): Target architecture.
         input_tensors (list): List of one input tensor.
         output_tensor: Output tensor.
+        op_params: Operation parameters.
     """
     raise NotImplementedError
 
 
-def ggml_unary_op_gelu_erf(arch: str, input_tensors: list, output_tensor):
+def ggml_unary_op_gelu_erf(
+    arch: str, input_tensors: list, output_tensor, op_params: bytearray
+):
     """
     GGML_UNARY_OP_GELU_ERF implementation.
 
@@ -481,11 +530,14 @@ def ggml_unary_op_gelu_erf(arch: str, input_tensors: list, output_tensor):
         arch (str): Target architecture.
         input_tensors (list): List of one input tensor.
         output_tensor: Output tensor.
+        op_params: Operation parameters.
     """
     raise NotImplementedError
 
 
-def ggml_unary_op_xielu(arch: str, input_tensors: list, output_tensor):
+def ggml_unary_op_xielu(
+    arch: str, input_tensors: list, output_tensor, op_params: bytearray
+):
     """
     GGML_UNARY_OP_XIELU implementation.
 
@@ -493,11 +545,14 @@ def ggml_unary_op_xielu(arch: str, input_tensors: list, output_tensor):
         arch (str): Target architecture.
         input_tensors (list): List of one input tensor.
         output_tensor: Output tensor.
+        op_params: Operation parameters.
     """
     raise NotImplementedError
 
 
-def ggml_unary_op_floor(arch: str, input_tensors: list, output_tensor):
+def ggml_unary_op_floor(
+    arch: str, input_tensors: list, output_tensor, op_params: bytearray
+):
     """
     GGML_UNARY_OP_FLOOR implementation.
 
@@ -505,6 +560,7 @@ def ggml_unary_op_floor(arch: str, input_tensors: list, output_tensor):
         arch (str): Target architecture.
         input_tensors (list): List of one input tensor.
         output_tensor: Output tensor.
+        op_params: Operation parameters.
     """
 
     core_function = create_external_function(
@@ -521,7 +577,9 @@ def ggml_unary_op_floor(arch: str, input_tensors: list, output_tensor):
     )
 
 
-def ggml_unary_op_ceil(arch: str, input_tensors: list, output_tensor):
+def ggml_unary_op_ceil(
+    arch: str, input_tensors: list, output_tensor, op_params: bytearray
+):
     """
     GGML_UNARY_OP_CEIL implementation.
 
@@ -529,6 +587,7 @@ def ggml_unary_op_ceil(arch: str, input_tensors: list, output_tensor):
         arch (str): Target architecture.
         input_tensors (list): List of one input tensor.
         output_tensor: Output tensor.
+        op_params: Operation parameters.
     """
 
     core_function = create_external_function(
@@ -545,7 +604,9 @@ def ggml_unary_op_ceil(arch: str, input_tensors: list, output_tensor):
     )
 
 
-def ggml_unary_op_round(arch: str, input_tensors: list, output_tensor):
+def ggml_unary_op_round(
+    arch: str, input_tensors: list, output_tensor, op_params: bytearray
+):
     """
     GGML_UNARY_OP_ROUND implementation.
 
@@ -553,6 +614,7 @@ def ggml_unary_op_round(arch: str, input_tensors: list, output_tensor):
         arch (str): Target architecture.
         input_tensors (list): List of one input tensor.
         output_tensor: Output tensor.
+        op_params: Operation parameters.
     """
 
     core_function = create_external_function(
@@ -569,7 +631,9 @@ def ggml_unary_op_round(arch: str, input_tensors: list, output_tensor):
     )
 
 
-def ggml_unary_op_trunc(arch: str, input_tensors: list, output_tensor):
+def ggml_unary_op_trunc(
+    arch: str, input_tensors: list, output_tensor, op_params: bytearray
+):
     """
     GGML_UNARY_OP_TRUNC implementation.
 
@@ -577,6 +641,7 @@ def ggml_unary_op_trunc(arch: str, input_tensors: list, output_tensor):
         arch (str): Target architecture.
         input_tensors (list): List of one input tensor.
         output_tensor: Output tensor.
+        op_params: Operation parameters.
     """
 
     core_function = create_external_function(

--- a/src/ggml-hsa/requirements.txt
+++ b/src/ggml-hsa/requirements.txt
@@ -1,6 +1,7 @@
 # Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
 
 pytest
+black
 
 # MLIR-AIE and LLVM-AIE (Peano) packages are not on the official PyPI, so they are
 # added as additional indices here.


### PR DESCRIPTION
Passing op_params to the kernels at compile time, encoding the op_params in the kernel name using hex encoding.

Verified the change by running: `GGML_HSA_KERNEL_CACHE_CLEAR=1 ./test-mul-mat-hsa`. The test passed, and I also confirmed that the expected mat-mul kernel name is generated.
