### PR TITLE
Implement softmax kernel

### DIFF
--- a/src/ggml-hsa/kernels/CMakeLists.txt
+++ b/src/ggml-hsa/kernels/CMakeLists.txt
@@ -17,6 +17,8 @@ if (GGML_HSA_JIT_COMPILE)
         ${CMAKE_CURRENT_SOURCE_DIR}/scale.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/scale.py
         ${CMAKE_CURRENT_SOURCE_DIR}/utils.py
+        ${CMAKE_CURRENT_SOURCE_DIR}/softmax.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/softmax.py
         )
     ggml_hsa_copy_files(ggml_hsa_copy_iron_files
         FILES

--- a/src/ggml-hsa/kernels/softmax.cc
+++ b/src/ggml-hsa/kernels/softmax.cc
@@ -1,0 +1,419 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All Rights Reserved.
+
+#include "ggml-aie.hpp"
+#include <aie_api/aie.hpp>
+
+#ifndef KERN_VEC_SIZE
+#define KERN_VEC_SIZE 16
+#endif
+
+template <int VecSize = KERN_VEC_SIZE>
+inline aie::vector<float, VecSize> vec_exp(aie::vector<float, VecSize>& x) {
+    // Taylor series coefficients in reverse order for Horner's method
+    constexpr float exp_coeffs[] = {
+        0.0000000001605904f, // 1/13!
+        0.0000000020876757f, // 1/12!
+        0.0000000250521084f, // 1/11!
+        0.0000002755731922f, // 1/10!
+        0.0000027557319224f, // 1/9!
+        0.0000248015873016f, // 1/8!
+        0.0001984126984127f, // 1/7!
+        0.0013888888888889f, // 1/6!
+        0.0083333333333333f, // 1/5!
+        0.0416666666666667f, // 1/4!
+        0.1666666666666667f, // 1/3!
+        0.5f,                // 1/2!
+        1.0f,                // 1/1!
+        1.0f                 // 1/0!
+    };
+    constexpr int NUM_EXP_COEFFS = sizeof(exp_coeffs) / sizeof(exp_coeffs[0]);
+
+    // clamp x to prevent overflow
+    aie::vector<float, VecSize> v_clamp_min = aie::broadcast<float, VecSize>(-88.0f);
+    aie::vector<float, VecSize> v_clamp_max = aie::broadcast<float, VecSize>(88.0f);
+    x = aie::max(x, v_clamp_min);
+    x = aie::min(x, v_clamp_max);
+
+    aie::accum<accfloat, VecSize> tmp_accum;
+    aie::vector<float, VecSize> poly = aie::broadcast<float, VecSize>(exp_coeffs[0]);
+
+#pragma unroll
+    for (int i = 1; i < NUM_EXP_COEFFS; ++i) {
+        tmp_accum = aie::mul(poly, x);
+        poly = tmp_accum.template to_vector<float>();
+        poly = aie::add(poly, aie::broadcast<float, VecSize>(exp_coeffs[i]));
+    }
+
+    // clamp to positive
+    aie::vector<float, VecSize> v_exp_min = aie::broadcast<float, VecSize>(1e-38f);
+    poly = aie::max(poly, v_exp_min);
+
+    return poly;
+}
+
+// Scalar 2^x using range reduction
+// Horner's method suffer from precision loss for large input values
+// We apply range reduction technique, which splits x into integer (i) and
+// fractional (f) parts where i = floor(x) and f is between 0 and 1.
+// Formula: 2^x = 2^i * 2^f
+inline float pow2(float x) {
+    // split x into integer and fractional parts
+    int i = (int)x;
+    if (x < (float)i) {
+        i--;
+    }
+    float f = x - (float)i;
+
+    constexpr float pow2_coeffs[] = {
+        0.0000000070549116f, // ln(2)^10 / 10!
+        0.0000001017808600f, // ln(2)^9 / 9!
+        0.0000013215486790f, // ln(2)^8 / 8!
+        0.0000152525277765f, // ln(2)^7 / 7!
+        0.0001540353039338f, // ln(2)^6 / 6!
+        0.0013333558146428f, // ln(2)^5 / 5!
+        0.0096181291076285f, // ln(2)^4 / 4!
+        0.0555041086648216f, // ln(2)^3 / 3!
+        0.2402265069591007f, // ln(2)^2 / 2!
+        0.6931471805599453f, // ln(2)^1 / 1!
+        1.0f                 // ln(2)^0 / 0!
+    };
+    constexpr int NUM_POW2_COEFFS = sizeof(pow2_coeffs) / sizeof(pow2_coeffs[0]);
+
+    // compute 2^f using Horner's method for Taylor series of exp(f * ln(2))
+    float exp_f = pow2_coeffs[0];
+
+#pragma unroll
+    for (int j = 1; j < NUM_POW2_COEFFS; ++j) {
+        exp_f = exp_f * f + pow2_coeffs[j];
+    }
+
+    // this takes a couple of cycles to compute 2^i using IEEE 754 bit manipulation
+    // IEEE 754 float: 2^i is represented as exponent = 127 + i, mantissa = 0
+    // create the integer representation of 2^i
+    int32_t bits = (127 + i) << 23;
+    // cast the bits directly to float
+    float scale = reinterpret_cast<float &>(bits);
+
+    return exp_f * scale;
+}
+
+// floor of log2 for positive integers
+// by finding the index of the most significant bit
+inline uint32_t floor_log2(uint32_t x) {
+    uint32_t result = 0;
+    while (x > 1) {
+        x >>= 1;
+        result++;
+    }
+    return result;
+}
+
+// ALiBi slope computation
+inline float compute_alibi_slope(float max_bias, int32_t n_head, int32_t head_idx) {
+    if (max_bias <= 0.0f) {
+        return 1.0f;
+    }
+
+    uint32_t n_head_log2 = 1u << floor_log2((uint32_t)n_head);
+
+    // compute base values m0 and m1
+    float m0 = pow2(-max_bias / n_head_log2);
+    float m1 = pow2(-(max_bias / 2.0f) / n_head_log2);
+
+    float slope;
+    if (head_idx < n_head_log2) {
+        // slope = m0^(head_idx+1) via repeated multiplication
+        slope = m0;
+        for (uint32_t j = 0; j < head_idx; ++j) {
+            slope *= m0;
+        }
+    } else {
+        // slope = m1^(2*(head_idx - n_head_log2) + 1)
+        uint32_t exp = 2 * (head_idx - n_head_log2) + 1;
+        slope = m1;
+        for (uint32_t j = 1; j < exp; ++j) {
+            slope *= m1;
+        }
+    }
+
+    return slope;
+}
+
+extern "C" {
+#ifdef COMPILE_GGML_OP_SOFTMAX
+// Softmax without mask or sink
+void ggml_op_softmax(const INPUT_DTYPE * __restrict in,
+                     OUTPUT_DTYPE * __restrict out,
+                     int32_t N,
+                     float scale,
+                     float max_bias) {
+    event0();
+
+    constexpr int VEC_SIZE = KERN_VEC_SIZE;
+    const int num_iters = N / VEC_SIZE;
+
+    auto it_in = aie::cbegin_vector<VEC_SIZE>((float *)in);
+    auto it_exp_out = aie::begin_vector<VEC_SIZE>((float *)out);
+    auto it_scale_in = aie::cbegin_restrict_vector<VEC_SIZE>((float *)out);
+    auto it_soft_out = aie::begin_restrict_vector<VEC_SIZE>((float *)out);
+
+    // find max value for numerical stability
+
+    auto it_max_in = aie::cbegin_vector<VEC_SIZE>((float *)in);
+    aie::vector<float, VEC_SIZE> v_max = aie::broadcast<float, VEC_SIZE>(-3.4028235e+38f);
+
+    for (int i = 0; i < num_iters; i++) {
+        aie::vector<float, VEC_SIZE> input_vec = *it_max_in++;
+        aie::accum<accfloat, VEC_SIZE> scaled_accum = aie::mul(input_vec, scale);
+        aie::vector<float, VEC_SIZE> scaled_input = scaled_accum.to_vector<float>();
+        v_max = aie::max(v_max, scaled_input);
+    }
+
+    float global_max = aie::reduce_max(v_max);
+    aie::vector<float, VEC_SIZE> v_global_max = aie::broadcast<float, VEC_SIZE>(global_max);
+
+    // compute exp(x - max) and sum
+
+    aie::accum<accfloat, VEC_SIZE> v_sum_accum = aie::zeros<accfloat, VEC_SIZE>();
+
+    for (int i = 0; i < num_iters; i++) {
+        aie::vector<float, VEC_SIZE> input_vec = *it_in++;
+
+        // apply scale
+        aie::accum<accfloat, VEC_SIZE> scaled_accum = aie::mul(input_vec, scale);
+        aie::vector<float, VEC_SIZE> scaled_input = scaled_accum.to_vector<float>();
+
+        // subtract max for numerical stability
+        aie::vector<float, VEC_SIZE> x = aie::sub(scaled_input, v_global_max);
+
+        // compute exp(x)
+        aie::vector<float, VEC_SIZE> exp_val = vec_exp<VEC_SIZE>(x);
+
+        // accumulate sum
+        v_sum_accum = aie::add(v_sum_accum, exp_val);
+
+        // store exp values
+        *it_exp_out++ = exp_val;
+    }
+
+    // normalize by dividing by sum
+
+    aie::vector<float, VEC_SIZE> v_sum_vec = v_sum_accum.to_vector<float>();
+    float sum_total = aie::reduce_add(v_sum_vec);
+    float sum_inv = aie::inv(sum_total);
+
+    for (int i = 0; i < num_iters; i++) {
+        aie::vector<float, VEC_SIZE> in_elems = *it_scale_in++;
+        aie::accum<accfloat, VEC_SIZE> out_accum = aie::mul(in_elems, sum_inv);
+        *it_soft_out++ = out_accum.to_vector<float>();
+    }
+
+    event1();
+}
+
+#endif // COMPILE_GGML_OP_SOFTMAX
+
+#ifdef COMPILE_GGML_OP_SOFTMAX_WITH_MASK
+// Softmax with mask tensor
+void ggml_op_softmax_with_mask(const INPUT_DTYPE * __restrict in,
+                               const MASK_DTYPE * __restrict mask,
+                               OUTPUT_DTYPE * __restrict out,
+                               int32_t N,
+                               float scale,
+                               float max_bias,
+                               int32_t n_head,
+                               int32_t tile_idx,
+                               int32_t rows_per_head) {
+    event0();
+
+    constexpr int VEC_SIZE = KERN_VEC_SIZE;
+    const int num_iters = N / VEC_SIZE;
+
+    // compute ALiBi slope
+    uint32_t head_idx = (uint32_t)(tile_idx / rows_per_head);
+    float slope = compute_alibi_slope(max_bias, (uint32_t)n_head, head_idx);
+
+    auto it_in = aie::cbegin_vector<VEC_SIZE>((float *)in);
+    auto it_mask = aie::cbegin_vector<VEC_SIZE>((float *)mask);
+    auto it_exp_out = aie::begin_vector<VEC_SIZE>((float *)out);
+    auto it_scale_in = aie::cbegin_restrict_vector<VEC_SIZE>((float *)out);
+    auto it_soft_out = aie::begin_restrict_vector<VEC_SIZE>((float *)out);
+
+    // find max(scale * in + slope * mask)
+
+    auto it_max_in = aie::cbegin_vector<VEC_SIZE>((float *)in);
+    auto it_max_mask = aie::cbegin_vector<VEC_SIZE>((float *)mask);
+    aie::vector<float, VEC_SIZE> v_max = aie::broadcast<float, VEC_SIZE>(-3.4028235e+38f);
+
+    for (int i = 0; i < num_iters; i++) {
+        aie::vector<float, VEC_SIZE> input_vec = *it_max_in++;
+        aie::vector<float, VEC_SIZE> mask_vec = *it_max_mask++;
+
+        // scaled_input = in * scale
+        aie::accum<accfloat, VEC_SIZE> scaled_accum = aie::mul(input_vec, scale);
+        aie::vector<float, VEC_SIZE> scaled_input = scaled_accum.to_vector<float>();
+
+        // scaled_mask = mask * slope (ALiBi)
+        aie::accum<accfloat, VEC_SIZE> mask_accum = aie::mul(mask_vec, slope);
+        aie::vector<float, VEC_SIZE> scaled_mask = mask_accum.to_vector<float>();
+
+        // masked_input = scaled_input + scaled_mask
+        aie::vector<float, VEC_SIZE> masked_input = aie::add(scaled_input, scaled_mask);
+
+        v_max = aie::max(v_max, masked_input);
+    }
+
+    float global_max = aie::reduce_max(v_max);
+    aie::vector<float, VEC_SIZE> v_global_max = aie::broadcast<float, VEC_SIZE>(global_max);
+
+    // compute exp(scale * in + slope * mask - max) and accumulate sum
+
+    aie::accum<accfloat, VEC_SIZE> v_sum_accum = aie::zeros<accfloat, VEC_SIZE>();
+
+    for (int i = 0; i < num_iters; i++) {
+        aie::vector<float, VEC_SIZE> input_vec = *it_in++;
+        aie::vector<float, VEC_SIZE> mask_vec = *it_mask++;
+
+        // scaled_input = in * scale
+        aie::accum<accfloat, VEC_SIZE> scaled_accum = aie::mul(input_vec, scale);
+        aie::vector<float, VEC_SIZE> scaled_input = scaled_accum.to_vector<float>();
+
+        // scaled_mask = mask * slope (ALiBi)
+        aie::accum<accfloat, VEC_SIZE> mask_accum = aie::mul(mask_vec, slope);
+        aie::vector<float, VEC_SIZE> scaled_mask = mask_accum.to_vector<float>();
+
+        // masked_input = scaled_input + scaled_mask
+        aie::vector<float, VEC_SIZE> masked_input = aie::add(scaled_input, scaled_mask);
+
+        // x = masked_input - max (numerical stability)
+        aie::vector<float, VEC_SIZE> x = aie::sub(masked_input, v_global_max);
+
+        // exp_val = exp(x)
+        aie::vector<float, VEC_SIZE> exp_val = vec_exp<VEC_SIZE>(x);
+
+        // accumulate sum
+        v_sum_accum = aie::add(v_sum_accum, exp_val);
+
+        // store exp values for normalization pass
+        *it_exp_out++ = exp_val;
+    }
+
+    // normalize by dividing by sum
+
+    aie::vector<float, VEC_SIZE> v_sum_vec = v_sum_accum.to_vector<float>();
+    float sum_total = aie::reduce_add(v_sum_vec);
+    float sum_inv = aie::inv(sum_total);
+
+    for (int i = 0; i < num_iters; i++) {
+        aie::vector<float, VEC_SIZE> in_elems = *it_scale_in++;
+        aie::accum<accfloat, VEC_SIZE> out_accum = aie::mul(in_elems, sum_inv);
+        *it_soft_out++ = out_accum.to_vector<float>();
+    }
+
+    event1();
+}
+
+#endif // COMPILE_GGML_OP_SOFTMAX_WITH_MASK
+
+#ifdef COMPILE_GGML_OP_SOFTMAX_WITH_MASK_AND_SINKS
+// Softmax with mask and sink tensors
+void ggml_op_softmax_with_mask_and_sinks(const INPUT_DTYPE * __restrict in,
+                                         const MASK_DTYPE * __restrict mask,
+                                         const SINK_DTYPE * __restrict sinks,
+                                         OUTPUT_DTYPE * __restrict out,
+                                         int32_t N,
+                                         int32_t tile_idx,
+                                         int32_t rows_per_head,
+                                         float scale,
+                                         float max_bias) {
+    event0();
+
+    constexpr int VEC_SIZE = KERN_VEC_SIZE;
+    const int num_iters = N / VEC_SIZE;
+
+    // calculate which head this tile belongs to and get the sink value
+    int32_t head_idx = tile_idx / rows_per_head;
+    float sink_val = sinks[head_idx];
+
+    auto it_in = aie::cbegin_vector<VEC_SIZE>((float *)in);
+    auto it_mask = aie::cbegin_vector<VEC_SIZE>((float *)mask);
+    auto it_exp_out = aie::begin_vector<VEC_SIZE>((float *)out);
+    auto it_scale_in = aie::cbegin_restrict_vector<VEC_SIZE>((float *)out);
+    auto it_soft_out = aie::begin_restrict_vector<VEC_SIZE>((float *)out);
+
+    // find max value for numerical stability
+    auto it_max_in = aie::cbegin_vector<VEC_SIZE>((float *)in);
+    auto it_max_mask = aie::cbegin_vector<VEC_SIZE>((float *)mask);
+    aie::vector<float, VEC_SIZE> v_max = aie::broadcast<float, VEC_SIZE>(-3.4028235e+38f);
+
+    for (int i = 0; i < num_iters; i++) {
+        aie::vector<float, VEC_SIZE> input_vec = *it_max_in++;
+        aie::vector<float, VEC_SIZE> mask_vec = *it_max_mask++;
+
+        // scaled_input = in * scale
+        aie::accum<accfloat, VEC_SIZE> scaled_accum = aie::mul(input_vec, scale);
+        aie::vector<float, VEC_SIZE> scaled_input = scaled_accum.to_vector<float>();
+
+        // masked_input = scaled_input + mask
+        aie::vector<float, VEC_SIZE> masked_input = aie::add(scaled_input, mask_vec);
+
+        v_max = aie::max(v_max, masked_input);
+    }
+
+    // reduce to scalar max, then include sink in max calculation
+    float global_max = aie::reduce_max(v_max);
+    global_max = (global_max > sink_val) ? global_max : sink_val;
+    aie::vector<float, VEC_SIZE> v_global_max = aie::broadcast<float, VEC_SIZE>(global_max);
+
+    // compute exp(scale * in + mask - max) and accumulate sum
+    aie::accum<accfloat, VEC_SIZE> v_sum_accum = aie::zeros<accfloat, VEC_SIZE>();
+
+    for (int i = 0; i < num_iters; i++) {
+        aie::vector<float, VEC_SIZE> input_vec = *it_in++;
+        aie::vector<float, VEC_SIZE> mask_vec = *it_mask++;
+
+        // scaled_input = in * scale
+        aie::accum<accfloat, VEC_SIZE> scaled_accum = aie::mul(input_vec, scale);
+        aie::vector<float, VEC_SIZE> scaled_input = scaled_accum.to_vector<float>();
+
+        // masked_input = scaled_input + mask
+        aie::vector<float, VEC_SIZE> masked_input = aie::add(scaled_input, mask_vec);
+
+        // x = masked_input - max (for numerical stability)
+        aie::vector<float, VEC_SIZE> x = aie::sub(masked_input, v_global_max);
+
+        // exp_val = exp(x)
+        aie::vector<float, VEC_SIZE> exp_val = vec_exp<VEC_SIZE>(x);
+
+        // accumulate sum
+        v_sum_accum = aie::add(v_sum_accum, exp_val);
+
+        // store exp values for normalization pass
+        *it_exp_out++ = exp_val;
+    }
+
+    // reduce sum across vector lanes
+    aie::vector<float, VEC_SIZE> v_sum_vec = v_sum_accum.to_vector<float>();
+    float sum_total = aie::reduce_add(v_sum_vec);
+
+    // compute exp(sink - max) using vec_exp and add to sum
+    float sink_shifted = sink_val - global_max;
+    aie::vector<float, VEC_SIZE> sink_vec = aie::broadcast<float, VEC_SIZE>(sink_shifted);
+    aie::vector<float, VEC_SIZE> sink_exp_vec = vec_exp<VEC_SIZE>(sink_vec);
+    float sink_exp = sink_exp_vec.get(0);
+
+    sum_total += sink_exp;
+    float sum_inv = aie::inv(sum_total);
+
+    // normalize by multiplying with 1/sum
+    for (int i = 0; i < num_iters; i++) {
+        aie::vector<float, VEC_SIZE> in_elems = *it_scale_in++;
+        aie::accum<accfloat, VEC_SIZE> out_accum = aie::mul(in_elems, sum_inv);
+        *it_soft_out++ = out_accum.to_vector<float>();
+    }
+
+    event1();
+}
+#endif // COMPILE_GGML_OP_SOFTMAX_WITH_MASK_AND_SINKS
+
+} // extern "C"

--- a/src/ggml-hsa/kernels/softmax.py
+++ b/src/ggml-hsa/kernels/softmax.py
@@ -1,0 +1,502 @@
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2026 Advanced Micro Devices, Inc. or its affiliates
+
+import struct
+from os import path
+from typing import Any, Optional, Tuple
+
+import numpy as np
+from aie.dialects.arith import index_cast
+from aie.ir import IntegerType
+from aie.iron import (
+    ExternalFunction,
+    ObjectFifo,
+    Program,
+    Runtime,
+    Worker,
+    dtype_to_str,
+)
+from aie.iron.controlflow import range_
+from aie.iron.placers import SequentialPlacer
+
+from build import (
+    align_to_arch,
+    arch_aligned_num_elements,
+    arch_to_device,
+    max_tile_size,
+)
+
+
+def get_softmax_dimensions(tensor) -> Tuple[int, int]:
+    """
+    Extract softmax dimensions from tensor shape.
+
+    GGML convention: softmax is over dimension 0 (ne00).
+    GGML shape ordering: (ne00, ne01, ne02, ne03) where ne00 is innermost.
+
+    Parameters:
+        tensor: Input tensor with shape in GGML order.
+
+    Returns:
+        Tuple of (row_length, num_rows) where:
+            - row_length = ne00 (dimension over which softmax is computed)
+            - num_rows = ne01 * ne02 * ne03 (number of independent rows)
+    """
+    shape = tensor.shape
+
+    if len(shape) == 1:
+        # shape = (ne00,)
+        return shape[0], 1
+    elif len(shape) == 2:
+        # shape = (ne00, ne01)
+        return shape[0], shape[1]
+    elif len(shape) == 3:
+        # shape = (ne00, ne01, ne02)
+        return shape[0], shape[1] * shape[2]
+    elif len(shape) == 4:
+        # shape = (ne00, ne01, ne02, ne03)
+        return shape[0], shape[1] * shape[2] * shape[3]
+    else:
+        raise ValueError(f"Unsupported tensor rank: {len(shape)}")
+
+
+# Vector size for AIE kernel vector operations
+KERN_VEC_SIZE = 8
+
+
+def ggml_op_softmax(
+    arch: str, input_tensors: list, output_tensor, op_params: bytearray
+):
+    """
+    GGML_OP_SOFTMAX implementation.
+
+    Parameters:
+        arch (str): Target architecture.
+        input_tensors (list): List of 1-3 input tensors:
+            - input_tensors[0]: Input tensor (required)
+            - input_tensors[1]: Mask tensor (optional)
+            - input_tensors[2]: Sink tensor (optional)
+        output_tensor: Output tensor.
+        op_params (bytearray): Operation parameters (scale, max_bias).
+    """
+
+    input_tensor_count = len(input_tensors)
+
+    if input_tensor_count < 1 or input_tensor_count > 3:
+        raise ValueError(f"Operation requires 1, 2, or 3 tensors: {input_tensor_count}")
+
+    input_tensor = input_tensors[0]
+    mask_tensor = input_tensors[1] if input_tensor_count >= 2 else None
+    sink_tensor = input_tensors[2] if input_tensor_count >= 3 else None
+
+    if not input_tensor.contiguous:
+        raise ValueError("Input tensor must be contiguous in memory.")
+    if not output_tensor.contiguous:
+        raise ValueError("Output tensor must be contiguous in memory.")
+    if mask_tensor is not None and not mask_tensor.contiguous:
+        raise ValueError("Mask tensor must be contiguous in memory.")
+
+    if sink_tensor is not None:
+        raise ValueError(
+            "Softmax with sink tensor is not supported on AIE. "
+            "AIE tiles are limited to 2 input DMA channels, but softmax with "
+            "mask and sink requires 3 input streams."
+        )
+    # Uncomment when the DMA-channel issue is resolved
+    # if sink_tensor is not None and not sink_tensor.contiguous:
+    #    raise ValueError("Sink tensor must be contiguous in memory.")
+
+    # Currently f16 mask is not supported as we use f32 vector instructions.
+    if mask_tensor is not None and mask_tensor.dtype == np.dtype("bfloat16"):
+        raise ValueError("Softmax with bfloat16 mask is not supported on AIE.")
+
+    if input_tensor.shape != output_tensor.shape:
+        raise ValueError("Input and output tensors must have the same shape.")
+
+    # Unpack op_params: scale and max_bias
+    scale = struct.unpack_from("f", op_params, 0)[0]
+    max_bias = struct.unpack_from("f", op_params, 4)[0]
+
+    op_name = "softmax"
+
+    if input_tensor_count == 1:
+        return create_unary_program(
+            arch, op_name, input_tensor, output_tensor, scale, max_bias
+        )
+    elif input_tensor_count == 2:
+        return create_binary_program(
+            arch, op_name, input_tensor, mask_tensor, output_tensor, scale, max_bias
+        )
+    else:  # input_tensor_count == 3
+        return create_ternary_program(
+            arch,
+            op_name,
+            input_tensor,
+            mask_tensor,
+            sink_tensor,
+            output_tensor,
+            scale,
+            max_bias,
+        )
+
+
+def create_unary_program(arch, op_name, input_tensor, output_tensor, scale, max_bias):
+    """Softmax without mask or sink encoding."""
+    function, num_elements, tile_size = create_external_function(
+        arch=arch,
+        op_name=op_name,
+        input_tensor=input_tensor,
+        mask_tensor=None,
+        sink_tensor=None,
+        output_tensor=output_tensor,
+    )
+
+    num_tiles = num_elements // tile_size
+    assert num_elements % tile_size == 0
+
+    input_tile_ty = np.ndarray[(tile_size,), np.dtype[input_tensor.dtype]]
+    output_tile_ty = np.ndarray[(tile_size,), np.dtype[output_tensor.dtype]]
+
+    of_in = ObjectFifo(input_tile_ty, name="in")
+    of_out = ObjectFifo(output_tile_ty, name="out")
+
+    def ext_core_fn(of_in, of_out, function):
+        for _ in range_(num_tiles):
+            elem_in = of_in.acquire(1)
+            elem_out = of_out.acquire(1)
+            function(elem_in, elem_out, tile_size, scale, max_bias)
+            of_in.release(1)
+            of_out.release(1)
+
+    worker = Worker(ext_core_fn, fn_args=[of_in.cons(), of_out.prod(), function])
+
+    rt = Runtime()
+    input_tensor_ty = np.ndarray[(num_elements,), np.dtype[input_tensor.dtype]]
+    output_tensor_ty = np.ndarray[(num_elements,), np.dtype[output_tensor.dtype]]
+
+    with rt.sequence(input_tensor_ty, output_tensor_ty) as (a_in, b_out):
+        rt.start(worker)
+        rt.fill(of_in.prod(), a_in)
+        rt.drain(of_out.cons(), b_out, wait=True)
+
+    return Program(arch_to_device(arch), rt).resolve_program(SequentialPlacer())
+
+
+def create_binary_program(
+    arch, op_name, input_tensor, mask_tensor, output_tensor, scale, max_bias
+):
+    """Softmax with mask tensor."""
+    func_result = create_external_function(
+        arch=arch,
+        op_name=op_name,
+        input_tensor=input_tensor,
+        mask_tensor=mask_tensor,
+        sink_tensor=None,
+        output_tensor=output_tensor,
+    )
+    function = func_result[0]
+    num_elements_in = func_result[1]
+    tile_size_in = func_result[2]
+    tile_size_mask = func_result[3]
+    num_rows_mask = func_result[4]
+    num_elements_mask = func_result[5]
+    n_head = func_result[6]
+    rows_per_head = func_result[7]
+
+    num_tiles_in = num_elements_in // tile_size_in
+    num_tiles_mask = num_elements_mask // tile_size_mask
+
+    assert num_elements_in % tile_size_in == 0
+    assert num_elements_mask % tile_size_mask == 0
+    assert num_elements_in == num_elements_mask
+    assert num_tiles_in == num_tiles_mask
+
+    input_tile_ty = np.ndarray[(tile_size_in,), np.dtype[input_tensor.dtype]]
+    mask_tile_ty = np.ndarray[(tile_size_mask,), np.dtype[mask_tensor.dtype]]
+    output_tile_ty = np.ndarray[(tile_size_in,), np.dtype[output_tensor.dtype]]
+
+    of_in = ObjectFifo(input_tile_ty, name="in")
+    of_mask = ObjectFifo(mask_tile_ty, name="mask")
+    of_out = ObjectFifo(output_tile_ty, name="out")
+
+    def ext_core_fn(of_in, of_mask, of_out, function):
+        for tile_idx in range_(num_tiles_in):
+            elem_in = of_in.acquire(1)
+            elem_mask = of_mask.acquire(1)
+            elem_out = of_out.acquire(1)
+
+            tile_idx_i32 = index_cast(IntegerType.get_signless(32), tile_idx)
+
+            function(
+                elem_in,
+                elem_mask,
+                elem_out,
+                tile_size_in,
+                scale,
+                max_bias,
+                n_head,
+                tile_idx_i32,
+                rows_per_head,
+            )
+            of_in.release(1)
+            of_mask.release(1)
+            of_out.release(1)
+
+    worker = Worker(
+        ext_core_fn, fn_args=[of_in.cons(), of_mask.cons(), of_out.prod(), function]
+    )
+
+    rt = Runtime()
+
+    input_tensor_ty = np.ndarray[(num_elements_in,), np.dtype[input_tensor.dtype]]
+    mask_tensor_ty = np.ndarray[(num_elements_mask,), np.dtype[mask_tensor.dtype]]
+    output_tensor_ty = np.ndarray[(num_elements_in,), np.dtype[output_tensor.dtype]]
+
+    with rt.sequence(input_tensor_ty, mask_tensor_ty, output_tensor_ty) as (
+        a_in,
+        a_mask,
+        b_out,
+    ):
+        rt.start(worker)
+        rt.fill(of_in.prod(), a_in)
+        rt.fill(of_mask.prod(), a_mask)
+        rt.drain(of_out.cons(), b_out, wait=True)
+
+    return Program(arch_to_device(arch), rt).resolve_program(SequentialPlacer())
+
+
+def create_ternary_program(
+    arch,
+    op_name,
+    input_tensor,
+    mask_tensor,
+    sink_tensor,
+    output_tensor,
+    scale,
+    max_bias,
+):
+    """
+    Softmax with mask tensor and sink tensor.
+
+    Sink tensor contains one value per head. The kernel receives the full
+    sink array and indexes into it based on tile_idx and rows_per_head.
+    """
+    func_result = create_external_function(
+        arch=arch,
+        op_name=op_name,
+        input_tensor=input_tensor,
+        mask_tensor=mask_tensor,
+        sink_tensor=sink_tensor,
+        output_tensor=output_tensor,
+    )
+
+    function = func_result[0]
+    num_elements_in = func_result[1]
+    tile_size_in = func_result[2]
+    tile_size_mask = func_result[3]
+    num_rows_mask = func_result[4]
+    num_elements_mask = func_result[5]
+    num_sinks = func_result[6]
+    rows_per_head = func_result[7]
+
+    num_tiles_in = num_elements_in // tile_size_in
+    num_tiles_mask = num_elements_mask // tile_size_mask
+
+    assert num_elements_in % tile_size_in == 0
+    assert num_elements_mask % tile_size_mask == 0
+    assert num_elements_in == num_elements_mask
+    assert num_tiles_in == num_tiles_mask
+
+    input_tile_ty = np.ndarray[(tile_size_in,), np.dtype[input_tensor.dtype]]
+    mask_tile_ty = np.ndarray[(tile_size_mask,), np.dtype[mask_tensor.dtype]]
+    output_tile_ty = np.ndarray[(tile_size_in,), np.dtype[output_tensor.dtype]]
+
+    # entire sink array passed once, not tiled
+    sink_array_ty = np.ndarray[(num_sinks,), np.dtype[sink_tensor.dtype]]
+
+    of_in = ObjectFifo(input_tile_ty, name="in")
+    of_mask = ObjectFifo(mask_tile_ty, name="mask")
+    of_sink = ObjectFifo(sink_array_ty, name="sink", depth=1)  # Single buffer
+    of_out = ObjectFifo(output_tile_ty, name="out")
+
+    def ext_core_fn(of_in, of_mask, of_sink, of_out, function):
+        # acquire sink array once at the start
+        sink_array = of_sink.acquire(1)
+
+        for tile_idx in range_(num_tiles_in):
+            elem_in = of_in.acquire(1)
+            elem_mask = of_mask.acquire(1)
+            elem_out = of_out.acquire(1)
+
+            # convert tile_idx from index type to i32
+            tile_idx_i32 = index_cast(IntegerType.get_signless(32), tile_idx)
+
+            function(
+                elem_in,
+                elem_mask,
+                sink_array,
+                elem_out,
+                tile_size_in,
+                tile_idx_i32,
+                rows_per_head,
+                scale,
+                max_bias,
+            )
+
+            of_in.release(1)
+            of_mask.release(1)
+            of_out.release(1)
+
+        # release sink array after all tiles processed
+        of_sink.release(1)
+
+    worker = Worker(
+        ext_core_fn,
+        fn_args=[of_in.cons(), of_mask.cons(), of_sink.cons(), of_out.prod(), function],
+    )
+
+    rt = Runtime()
+
+    input_tensor_ty = np.ndarray[(num_elements_in,), np.dtype[input_tensor.dtype]]
+    mask_tensor_ty = np.ndarray[(num_elements_mask,), np.dtype[mask_tensor.dtype]]
+    sink_tensor_ty = np.ndarray[(num_sinks,), np.dtype[sink_tensor.dtype]]
+    output_tensor_ty = np.ndarray[(num_elements_in,), np.dtype[output_tensor.dtype]]
+
+    with rt.sequence(
+        input_tensor_ty, mask_tensor_ty, sink_tensor_ty, output_tensor_ty
+    ) as (a_in, a_mask, a_sink, b_out):
+        rt.start(worker)
+        rt.fill(of_in.prod(), a_in)
+        rt.fill(of_mask.prod(), a_mask)
+        rt.fill(of_sink.prod(), a_sink)
+        rt.drain(of_out.cons(), b_out, wait=True)
+
+    return Program(arch_to_device(arch), rt).resolve_program(SequentialPlacer())
+
+
+def create_external_function(
+    arch: str,
+    op_name: str,
+    input_tensor: Any,
+    mask_tensor: Optional[Any],
+    sink_tensor: Optional[Any],
+    output_tensor: Any,
+) -> Tuple:
+    """
+    Creates an external function specification for softmax variants.
+
+    Returns:
+        If no mask or sink tensor:
+            (func, num_elements_in, tile_size_in)
+        If mask tensor only:
+            (func, num_elements_in, tile_size_in, tile_size_mask, num_rows_mask, num_elements_mask, n_head, rows_per_head)
+        If mask and sink tensor:
+            (func, num_elements_in, tile_size_in, tile_size_mask, num_rows_mask, num_elements_mask, num_sinks, rows_per_head)
+    """
+    row_length_in, num_rows_in = get_softmax_dimensions(input_tensor)
+
+    # Probably aligning doesn't make sense as we already do not allow unaligned
+    # inputs but keeping this as we'll need it in the future
+    tile_size_in = align_to_arch(arch, row_length_in, input_tensor.dtype, KERN_VEC_SIZE)
+
+    # Currently we do not support unaligned row sizes as we use vector
+    # instructions with a fixed length.
+    if row_length_in % KERN_VEC_SIZE != 0:
+        raise ValueError(
+            f"Input row length ({row_length_in}) must be a multiple of {KERN_VEC_SIZE}. "
+        )
+    num_elements_in = tile_size_in * num_rows_in
+
+    arg_types = [np.ndarray[(tile_size_in,), np.dtype[input_tensor.dtype]]]
+    compile_flags = [
+        f"-DINPUT_DTYPE={dtype_to_str(input_tensor.dtype)}",
+        f"-DKERN_VEC_SIZE={KERN_VEC_SIZE}",
+    ]
+
+    result_extra = []
+
+    if mask_tensor is not None:
+        row_length_mask, num_rows_mask = get_softmax_dimensions(mask_tensor)
+        tile_size_mask = align_to_arch(
+            arch, row_length_mask, mask_tensor.dtype, KERN_VEC_SIZE
+        )
+        tile_size_mask = align_to_arch(
+            arch, row_length_mask, mask_tensor.dtype, KERN_VEC_SIZE
+        )
+        num_elements_mask = tile_size_mask * num_rows_mask
+
+        if row_length_mask % KERN_VEC_SIZE != 0:
+            raise ValueError(
+                f"Mask row length ({row_length_mask}) must be a multiple of {KERN_VEC_SIZE}. "
+            )
+
+        arg_types.append(np.ndarray[(tile_size_mask,), np.dtype[mask_tensor.dtype]])
+        compile_flags.append(f"-DMASK_DTYPE={dtype_to_str(mask_tensor.dtype)}")
+        result_extra.extend([tile_size_mask, num_rows_mask, num_elements_mask])
+
+        input_shape = input_tensor.shape
+        if len(input_shape) >= 3:
+            n_head = input_shape[2]  # ne02
+        elif len(input_shape) == 2:
+            n_head = 1
+        else:
+            n_head = 1
+
+        rows_per_head = num_rows_in // n_head if n_head > 0 else 1
+        result_extra.extend([n_head, rows_per_head])
+
+    if sink_tensor is not None:
+        # sink is 1D: one value per head
+        num_sinks = sink_tensor.shape[0]
+        rows_per_head = num_rows_in // num_sinks if num_sinks > 0 else 1
+
+        arg_types.append(np.ndarray[(num_sinks,), np.dtype[sink_tensor.dtype]])
+        compile_flags.append(f"-DSINK_DTYPE={dtype_to_str(sink_tensor.dtype)}")
+        if mask_tensor is not None:
+            result_extra = result_extra[:-2]
+        result_extra.extend([num_sinks, rows_per_head])
+
+    # output tensor
+    arg_types.append(np.ndarray[(tile_size_in,), np.dtype[output_tensor.dtype]])
+    compile_flags.append(f"-DOUTPUT_DTYPE={dtype_to_str(output_tensor.dtype)}")
+
+    arg_types.append(np.int32)  # tile_size
+
+    # additional arguments for sink variant
+    if sink_tensor is not None:
+        arg_types.append(np.int32)  # tile_idx
+        arg_types.append(np.int32)  # rows_per_head
+
+    arg_types.append(np.float32)  # scale
+    arg_types.append(np.float32)  # max_bias
+
+    # add ALiBi parameters for mask variant (without sink)
+    if mask_tensor is not None and sink_tensor is None:
+        arg_types.append(np.int32)  # n_head
+        arg_types.append(np.int32)  # tile_idx (passed dynamically)
+        arg_types.append(np.int32)  # rows_per_head
+    # determine function name and compile directive
+    if mask_tensor is not None and sink_tensor is not None:
+        function_name = f"ggml_op_{op_name}_with_mask_and_sinks"
+        compile_flags.append("-DCOMPILE_GGML_OP_SOFTMAX_WITH_MASK_AND_SINKS")
+    elif mask_tensor is not None:
+        function_name = f"ggml_op_{op_name}_with_mask"
+        compile_flags.append("-DCOMPILE_GGML_OP_SOFTMAX_WITH_MASK")
+    else:
+        function_name = f"ggml_op_{op_name}"
+        compile_flags.append("-DCOMPILE_GGML_OP_SOFTMAX")
+
+    current_dir = path.dirname(path.realpath(__file__))
+    func = ExternalFunction(
+        name=function_name,
+        object_file_name=f"{op_name}_core_function.o",
+        source_file=path.join(current_dir, "softmax.cc"),
+        arg_types=arg_types,
+        compile_flags=compile_flags,
+    )
+
+    return (func, num_elements_in, tile_size_in, *result_extra)


### PR DESCRIPTION
Current Limitations:

* Sink Tensor Support: Sink tensors are currently not supported due to insufficient DMA channels. The current algorithm requires 3 FIFO objects, but the IRON appears to support a maximum of 2.
* Mask Tensor Type: f16 mask tensors are not supported. 
* Input Alignment: The input tensor size must be a multiple of 8, as determined by the KERN_VEC_SIZE variable in softmax.py. Note that I tested a vector size of 16 as well, which also works and may offer better performance due to better parallelization. To remove the input size constraint, we probably need to do masked load and stores in the kernels. My second idea to address it is to assign big negative numbers to the masked elements, which i believe should work too (not  implemented)

## TEST RESULTS

1. SOFT_MAX WITHOUT MASK AND SINK:

SOFT_MAX(type=f32,ne=[16,16,1,1],mask=0,sinks=0,m_prec=f32,nr23=[1,1],scale=1.000000,max_bias=0.000000,inplace=0): OK

2. SOFT_MAX WITH MASK WITHOUT SINK

SOFT_MAX(type=f32,ne=[16,16,1,1],mask=1,sinks=0,m_prec=f32,nr23=[1,1],scale=1.000000,max_bias=0.000000,inplace=0): OK
SOFT_MAX(type=f32,ne=[16,1024,1,1],mask=1,sinks=0,m_prec=f32,nr23=[1,1],scale=1.000000,max_bias=0.000000,inplace=0): OK

2.A. SCALE TEST:

SOFT_MAX(type=f32,ne=[16,16,1,1],mask=1,sinks=0,m_prec=f32,nr23=[1,1],scale=0.100000,max_bias=0.000000,inplace=0): OK

2.B. AliBi TEST:

SOFT_MAX(type=f32,ne=[16,16,1,1],mask=1,sinks=0,m_prec=f32,nr23=[1,1],scale=1.000000,max_bias=8.000000,inplace=0): OK
SOFT_MAX(type=f32,ne=[1024,16,1,1],mask=1,sinks=0,m_prec=f32,nr23=[1,1],scale=1.000000,max_bias=8.000000,inplace=0): OK

2.C. AliBi with SCALE TEST:

SOFT_MAX(type=f32,ne=[16,16,1,1],mask=1,sinks=0,m_prec=f32,nr23=[1,1],scale=0.100000,max_bias=8.000000,inplace=0): OK
SOFT_MAX(type=f32,ne=[16,1024,1,1],mask=1,sinks=0,m_prec=f32,nr23=[1,1],scale=0.100000,max_bias=8.000000,inplace=0): OK
SOFT_MAX(type=f32,ne=[1024,16,1,1],mask=1,sinks=0,m_prec=f32,nr23=[1,1],scale=0.100000,max_bias=8.000000,inplace=0): OK

3. SOFT_MAX WITH MASK AND SINK (NOT SUPPORTED)
  
SOFT_MAX(type=f32,ne=[16,16,1,1],mask=1,sinks=1,m_prec=f32,nr23=[1,1],scale=1.000000,max_bias=0.000000,inplace=0): not supported [HSA0] 
ggml_hsa_compile_aie_kernel: failed to compile kernel soft_max-15x15f32-15x15f32-15x15f32-1f32-87a559f4792c3879 for tensor "out" (SOFT_MAX): ValueError: Softmax with sink tensor is not supported on AIE. AIE tiles are limited to 2 input DMA channels, but softmax with mask and sink requires 3 input streams.

OTHER FAILED TESTS:

I saw a bunch of failed tests due to "Input row length (15) must be a multiple of 8." like this SOFT_MAX(type=f32,ne=[15,15,1,1],mask=0,sinks=0,m_prec=f32,nr23=[1,1],scale=1.000000,max_bias=0.000000,inplace=0)
